### PR TITLE
Use steady_timer replace old deadlime_timer, remove date_time library  dependency on windows platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else ()
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -std=c++17")
 endif ()
 
-find_package(Boost 1.60 REQUIRED COMPONENTS system date_time)
+find_package(Boost 1.60 REQUIRED COMPONENTS system)
 
 set(CINATRA
 	http_server.hpp

--- a/connection.hpp
+++ b/connection.hpp
@@ -51,7 +51,7 @@ namespace cinatra {
 		}
 
 		void reset_timer() {
-			timer_.expires_from_now(boost::posix_time::seconds(KEEP_ALIVE_TIMEOUT_));
+			timer_.expires_from_now(std::chrono::seconds(KEEP_ALIVE_TIMEOUT_));
 			auto self = this->shared_from_this();
 
 			timer_.async_wait([self](boost::system::error_code const& ec) {
@@ -821,7 +821,7 @@ namespace cinatra {
 		//-----------------send message----------------//
 
 		socket_type socket_;
-		boost::asio::deadline_timer timer_;
+		boost::asio::steady_timer timer_;
 		request req_;
 		response res_;
 		websocket ws_;


### PR DESCRIPTION
把date_time相依性拔掉之後, 才可以開始進一步用standalone asio