### PR TITLE
io_service_inplace

### DIFF
--- a/io_service_pool.hpp
+++ b/io_service_pool.hpp
@@ -82,7 +82,7 @@ namespace cinatra
 			io_services_->run();
 		}
 
-		intptr_t run_one(){
+		intptr_t run_one() {
 			return io_services_->run_one();
 		}
 
@@ -98,12 +98,7 @@ namespace cinatra
 			work_ = nullptr;
 
 			if (io_services_)
-			{
-				io_services_->run();
 				io_services_->stop();
-
-				io_services_ = nullptr;
-			}
 		}
 
 		boost::asio::io_service& get_io_service() {

--- a/use_asio.hpp
+++ b/use_asio.hpp
@@ -4,6 +4,9 @@
 //MSVC : define environment path 'ASIO_STANDALONE_INCLUDE', e.g. 'E:\bdlibs\asio-1.10.6\include'
 
 #include <asio.hpp>
+#ifdef CINATRA_ENABLE_SSL
+#include <asio/ssl.hpp>
+#endif
 #include <asio/steady_timer.hpp>
 namespace boost
 {

--- a/utils.hpp
+++ b/utils.hpp
@@ -4,11 +4,14 @@
 
 #ifndef CINATRA_UTILS_HPP
 #define CINATRA_UTILS_HPP
+
+#pragma once
 #include <string>
 #include <string_view>
 #include <cstdlib>
 #include <cctype>
 #include <type_traits>
+#include <algorithm>
 
 namespace cinatra {
 	struct ci_less
@@ -79,18 +82,18 @@ namespace cinatra {
 	};
 
 	inline std::string_view trim_left(std::string_view v) {
-		v.remove_prefix(std::min(v.find_first_not_of(" "), v.size()));
+		v.remove_prefix((std::min)(v.find_first_not_of(" "), v.size()));
 		return v;
 	}
 
 	inline std::string_view trim_right(std::string_view v) {
-		v.remove_suffix(std::min(v.size() - v.find_last_not_of(" ") - 1, v.size()));
+		v.remove_suffix((std::min)(v.size() - v.find_last_not_of(" ") - 1, v.size()));
 		return v;
 	}
 
 	inline std::string_view trim(std::string_view v) {
-		v.remove_prefix(std::min(v.find_first_not_of(" "), v.size()));
-		v.remove_suffix(std::min(v.size() - v.find_last_not_of(" ") - 1, v.size()));
+		v.remove_prefix((std::min)(v.find_first_not_of(" "), v.size()));
+		v.remove_suffix((std::min)(v.size() - v.find_last_not_of(" ") - 1, v.size()));
 		return v;
 	}
 
@@ -296,6 +299,7 @@ namespace cinatra {
 			return value;
 		}
 		else {
+			static_assert(false, "this type has not supported yet");
 			std::cout << "this type has not supported yet" << std::endl;
 		}
 	}


### PR DESCRIPTION
在尽量不修改原始代码的基础上，增加了一个io_service_inplace 实现，用来替换io_service_pool，实现可在第三方代码的线程里，就地跑http_server。