### PR TITLE
url边界修复

### DIFF
--- a/http_router.hpp
+++ b/http_router.hpp
@@ -38,6 +38,7 @@ namespace cinatra {
 		bool route(std::string_view method, std::string_view url, const request& req, response& res) {
 			std::string key(method.data(), method.length());
 			if (url.rfind('.') == std::string_view::npos) {
+				url = url.substr(url.size()-1,url.size())=="/"?url.substr(0,url.size()-1):url;
 				auto pos = url.rfind("index"sv);
 				if (pos != std::string_view::npos)
 					key += url.substr(0, pos == 1 ? 1 : pos - 1);


### PR DESCRIPTION
增加了 url 边界有反斜杠 找不到url的问题 
定义了了/home  的action
在浏览器中输入localhost:8080/home/  返回url not right 的问题