### PR TITLE
Fixed typographical error STAIC_RES -> STATIC_RESOURCE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,9 @@ cmake-build-debug
 *.exe
 *.out
 *.app
+
+# Eclipse
+/build/
+.project
+.cproject
+.settings

--- a/include/cinatra/define.h
+++ b/include/cinatra/define.h
@@ -17,6 +17,6 @@ namespace cinatra {
         none
 	};
 
-	inline const std::string_view STAIC_RES = "cinatra_staic_resource";
+	inline const std::string_view STATIC_RESOURCE = "cinatra_static_resource";
 	inline const std::string CSESSIONID = "CSESSIONID";
 }

--- a/include/cinatra/http_router.hpp
+++ b/include/cinatra/http_router.hpp
@@ -64,7 +64,7 @@ namespace cinatra {
 					key += std::string(url.data(), url.length());
 			}
 			else {
-				key += std::string(STAIC_RES.data(), STAIC_RES.length());
+				key += std::string(STATIC_RESOURCE.data(), STATIC_RESOURCE.length());
 				is_static_res_flag = true;
 			}
 

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -248,7 +248,7 @@ namespace cinatra {
 
 		void set_static_res_handler()
 		{
-			set_http_handler<POST,GET>(STAIC_RES, [this](request& req, response& res){
+			set_http_handler<POST,GET>(STATIC_RESOURCE, [this](request& req, response& res){
 				auto state = req.get_state();
 				switch (state) {
 					case cinatra::data_proc_state::data_begin:


### PR DESCRIPTION
Hi,

I was digging into the code, trying to have a better understanding of cinatra and I found that there's a typographical error for the static resource definition.  I hereby propose to fix the typo and make the name clearer: STATIC_RESOURCE instead of simply STA(T)IC_RES, as "RES" is often associated with "response".

Cheers,
Allister
