### PR TITLE
Global request handler and Handler level response file (absolute path)

### DIFF
--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -314,7 +314,12 @@ namespace cinatra {
 					case cinatra::data_proc_state::data_begin:
 					{
 						std::string relative_file_name = req.get_relative_filename();
-						std::string fullpath = static_dir_ + relative_file_name;
+						std::string fullpath = res.get_static_file_abs_url();
+						if(fullpath.length()==0) {
+							fullpath = static_dir_ + relative_file_name;
+						} else {
+							relative_file_name = fs::path(fullpath).filename().string();
+						}
 
 						auto mime = req.get_mime(relative_file_name);
 						auto in = std::make_shared<std::ifstream>(fullpath, std::ios_base::binary);

--- a/include/cinatra/response.hpp
+++ b/include/cinatra/response.hpp
@@ -358,6 +358,16 @@ namespace cinatra {
 			}
 		}
 
+		void set_static_file_abs_url(const std::string& static_file_path)
+		{
+			static_file_abs_url_ = static_file_path;
+		}
+
+		const std::string& get_static_file_abs_url()
+		{
+			return static_file_abs_url_;
+		}
+
 	private:
 		std::string_view get_header_value(std::string_view key) const {
 			phr_header* headers = req_headers_.first;
@@ -390,6 +400,7 @@ namespace cinatra {
 		std::string last_date_str_;
         res_content_type res_type_;
         bool need_response_time_ = false;
+	std::string static_file_abs_url_;
 	};
 }
 #endif //CINATRA_RESPONSE_HPP


### PR DESCRIPTION
Support for global handler which serves all methods and paths -- /*
Support for handler level static file setting in the response object (imagine a scenario where the handler wants to set a custom file as the response and wants to use cinatra's file handling and processing logic (absolute file path)

There is currently no support for global request handler
There is currently limited support for static file handling and only one static directory can be set as the global path for static file serving