### PR TITLE
Changing aspect_data_ to unordered_map<std::string, std::any>

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ cinatra是header-only的，直接引用头文件既可。
 				res.set_status_and_content(status_type::bad_request);
 				return false;
 			}
-			
 			return true;
 		}
 	
@@ -132,13 +131,26 @@ cinatra是header-only的，直接引用头文件既可。
 			return true;
 		}
 	};
-	
+
+	//将信息从中间件传输到处理程序
+	struct get_data {
+		bool before(request& req, response& res) {
+			req.set_aspect_data("hello", std::string("hello world"));
+			return true;
+		}
+	}
+
 	int main() {
 		http_server server(std::thread::hardware_concurrency());
 		server.listen("0.0.0.0", "8080");
 		server.set_http_handler<GET, POST>("/aspect", [](request& req, response& res) {
 			res.set_status_and_content(status_type::ok, "hello world");
 		}, check{}, log_t{});
+
+		server.set_http_handler<GET,POST>("/aspect/data", [](request& req, response& res) {
+			std::string hello = req.get_aspect_data<std::string>("hello");
+			res.set_status_and_content(status_type::ok, std::move(hello));
+		}, get_data{});
 
 		server.run();
 		return 0;

--- a/include/cinatra/request.hpp
+++ b/include/cinatra/request.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <fstream>
+#include <any>
 #include "picohttpparser.h"
 #include "utils.hpp"
 #include "multipart_reader.hpp"
@@ -768,15 +769,13 @@ public:
       event_call_backs_[(size_t)event_type](*this);
   }
 
-  template <typename... T> void set_aspect_data(T &&... data) {
-    (aspect_data_.push_back(std::forward<T>(data)), ...);
+  void set_aspect_data(const std::string&& key, const std::any &data) {
+    aspect_data_.insert({ key, data });
   }
 
-  void set_aspect_data(std::vector<std::string> &&data) {
-    aspect_data_ = std::move(data);
+  template <typename T> T get_aspect_data(const std::string&& key) {
+    return std::any_cast<T>(aspect_data_[key]);
   }
-
-  std::vector<std::string> get_aspect_data() { return std::move(aspect_data_); }
 
   void set_last_len(size_t len) { last_len_ = len; }
 
@@ -881,7 +880,7 @@ private:
   std::int64_t range_start_pos_ = 0;
   bool is_range_resource_ = 0;
   std::int64_t static_resource_file_size_ = 0;
-  std::vector<std::string> aspect_data_;
+  std::unordered_map<std::string, std::any> aspect_data_;
   std::array<event_call_back, (size_t)data_proc_state::data_error + 1>
       event_call_backs_ = {};
 };

--- a/lang/english/README.md
+++ b/lang/english/README.md
@@ -113,7 +113,6 @@ struct check {
 			res.set_status_and_content(status_type::bad_request);
 			return false;
 		}
-		
 		return true;
 	}
 
@@ -123,12 +122,25 @@ struct check {
 	}
 };
 
+// transfer data from aspect to http handler
+struct get_data {
+	bool before(request& req, response& res) {
+		req.set_aspect_data("hello", std::string("hello world"));
+		return true;
+	}
+}
+
 int main() {
 	http_server server(std::thread::hardware_concurrency());
 	server.listen("0.0.0.0", "8080");
 	server.set_http_handler<GET, POST>("/aspect", [](request& req, response& res) {
 		res.set_status_and_content(status_type::ok, "hello world");
 	}, check{}, log_t{});
+
+	server.set_http_handler<GET,POST>("/aspect/data", [](request& req, response& res) {
+		std::string hello = req.get_aspect_data<std::string>("hello");
+		res.set_status_and_content(status_type::ok, std::move(hello));
+	}, get_data{});
 
 	server.run();
 	return 0;


### PR DESCRIPTION
enables to transfer copyable objects from aspect-middleware to request handler.

example:
```
struct get_data {
	bool before(request& req, response& res) {
		req.set_aspect_data("hello", std::string("hello world"));
		return true;
	}
}
server.set_http_handler<GET,POST>("/aspect/data", [](request& req, response& res) {
	std::string hello = req.get_aspect_data<std::string>("hello");
	res.set_status_and_content(status_type::ok, std::move(hello));
}, get_data{});

```
