### PR TITLE
Revert "fix keep alive"

### DIFF
--- a/include/cinatra/connection.hpp
+++ b/include/cinatra/connection.hpp
@@ -181,10 +181,6 @@ public:
 
   auto &get_tag() { return tag_; }
 
-  bool get_keep_alive(){
-    return keep_alive_;
-  }
-
   template <typename... Fs> void send_ws_string(std::string msg, Fs &&...fs) {
     send_ws_msg(std::move(msg), opcode::text, std::forward<Fs>(fs)...);
   }
@@ -257,9 +253,6 @@ public:
                                }
 
                                call_back();
-                               if(keep_alive_){
-                                  do_read();
-                               }
                              });
   }
 

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -348,8 +348,7 @@ private:
           } break;
           case cinatra::data_proc_state::data_end: {
             auto conn = req.get_conn<ScoketType>();
-            if(!conn->get_keep_alive())
-              conn->on_close();
+            conn->on_close();
           } break;
           case cinatra::data_proc_state::data_all_end: {
             // network error


### PR DESCRIPTION
Reverts qicosmos/cinatra#204
I found that there is something wrong with this fix. The keep-alive connection can only be reused by request for static files. I will try to fix as soon as possible.