### PR TITLE
fix the blocking problem.

### DIFF
--- a/include/cinatra/connection.hpp
+++ b/include/cinatra/connection.hpp
@@ -413,9 +413,9 @@ private:
   }
 
   void handle_request(std::size_t bytes_transferred) {
+    auto type = get_content_type();
+    req_.set_http_type(type);
     if (req_.has_body()) {
-      auto type = get_content_type();
-      req_.set_http_type(type);
       switch (type) {
       case cinatra::content_type::string:
       case cinatra::content_type::websocket:

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -328,10 +328,10 @@ private:
 
             req.get_conn<ScoketType>()->set_tag(in);
 
-            // if(is_small_file(in.get(),req)){
-            //	send_small_file(res, in.get(), mime);
-            //	return;
-            //}
+            if(is_small_file(in.get(),req)){
+            	send_small_file(res, in.get(), mime);
+            	return;
+            }
 
             if (transfer_type_ == transfer_type::CHUNKED)
               write_chunked_header(req, in, mime);


### PR DESCRIPTION
The connection will be blocked after serving the static files.
Before merging the previous fix (#204  ), cinatra will close the connection after serving the static file, during which the `content_type` will be set to 3 (chunked). But when the next request comes with the same connection, the `content_type` isn't parsed and set correctly.
As a result, the requests with other content type will still have the wrong `chunked` content type and cinatra returns this request accidently with the connection opening.