### PR TITLE
修复启用GZIP之后返回内容错误的问题

### DIFF
--- a/include/cinatra/response.hpp
+++ b/include/cinatra/response.hpp
@@ -187,8 +187,10 @@ public:
       }
     } else
 #endif
+    {
       (void)encoding;
-    set_content(std::move(content));
+      set_content(std::move(content));
+    }
     build_response_str();
   }
 


### PR DESCRIPTION
在启用CINATRA_ENABLE_GZIP之后, 返回的数据会被set_content重新设置为未压缩的数据, 导致浏览器无法正常解析