### PR TITLE
feat: add quit when signal emitted in cinatra_example.

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -473,6 +473,19 @@ int main() {
   // http://127.0.0.1:8080/assets/show.jpg
   // cinatra will send you the file, if the file is big file(more than 5M) the
   // file will be downloaded by chunked
+
+  asio::signal_set signals(server.get_io_service());
+
+  signals.add(SIGINT);
+  signals.add(SIGTERM);
+#if defined(SIGQUIT)
+  signals.add(SIGQUIT);
+#endif
+  signals.async_wait([&server](asio::error_code ec, int) {
+    std::cout << "Stop server since receive signal to quit." << std::endl;
+    server.stop();
+  });
+
   server.run();
   return 0;
 }

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -140,6 +140,10 @@ public:
 
   intptr_t poll_one() { return io_service_pool_.poll_one(); }
 
+  asio::io_service &get_io_service() {
+    return io_service_pool_.get_io_service();
+  }
+
   void set_static_dir(std::string path) {
     set_file_dir(std::move(path), static_dir_);
   }


### PR DESCRIPTION
1. 在httpserver处增加get_io_service的代理方法.
2. cinatra_example的main.cpp增加信号退出的功能.