### PR TITLE
feat:add proxy support

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -259,6 +259,16 @@ class coro_http_client {
     proxy_port_ = port;
   }
 
+  inline void set_proxy_basic_auth(const std::string &username,
+                                   const std::string &password) {
+    proxy_basic_auth_username_ = username;
+    proxy_basic_auth_password_ = password;
+  }
+
+  inline void set_proxy_bearer_token_auth(const std::string &token) {
+    proxy_bearer_token_auth_token_ = token;
+  }
+
  private:
   std::pair<bool, uri_t> handle_uri(resp_data &data, const std::string &uri) {
     uri_t u;
@@ -324,6 +334,22 @@ class coro_http_client {
 
     if (!ctx.req_str.empty())
       req_str.append(ctx.req_str);
+
+    if (!proxy_basic_auth_username_.empty() &&
+        !proxy_basic_auth_password_.empty()) {
+      std::string basic_auth_str = "Proxy-Authorization: Basic ";
+      std::string basic_user_pass_str =
+          proxy_basic_auth_username_ + ":" + proxy_basic_auth_password_;
+      std::string basic_base64_str = base64_encode(basic_user_pass_str);
+      req_str.append(basic_auth_str).append(basic_base64_str).append(CRCF);
+    }
+
+    if (!proxy_bearer_token_auth_token_.empty()) {
+      std::string bearer_token_str = "Proxy-Authorization: Bearer ";
+      req_str.append(bearer_token_str)
+          .append(proxy_bearer_token_auth_token_)
+          .append(CRCF);
+    }
 
     // add content
     size_t content_len = ctx.content.size();
@@ -490,5 +516,10 @@ class coro_http_client {
 
   std::string proxy_host_;
   int proxy_port_ = -1;
+
+  std::string proxy_basic_auth_username_;
+  std::string proxy_basic_auth_password_;
+
+  std::string proxy_bearer_token_auth_token_;
 };
 }  // namespace cinatra

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -224,3 +224,14 @@ TEST_CASE("test basic http request") {
   server.stop();
   server_thread.join();
 }
+#if ENABLE_PROXY_SERVER
+TEST_CASE("test coro http proxy request") {
+  coro_http_client client{};
+  std::string uri = "http://www.baidu.com";
+  // Make sure the host and port are matching with your proxy server
+  client.set_proxy("192.168.102.1", 7890);
+  resp_data result = async_simple::coro::syncAwait(client.async_get(uri));
+  CHECK(!r.net_err);
+  CHECK(r.status == status_type::ok);
+}
+#endif

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -231,7 +231,25 @@ TEST_CASE("test coro http proxy request") {
   // Make sure the host and port are matching with your proxy server
   client.set_proxy("192.168.102.1", 7890);
   resp_data result = async_simple::coro::syncAwait(client.async_get(uri));
-  CHECK(!r.net_err);
-  CHECK(r.status == status_type::ok);
+  CHECK(!result.net_err);
+  CHECK(result.status == status_type::ok);
 }
 #endif
+
+TEST_CASE("test coro http basic auth request") {
+  coro_http_client client{};
+  std::string uri = "http://www.baidu.com";
+  client.set_proxy_basic_auth("user", "pass");
+  resp_data result = async_simple::coro::syncAwait(client.async_get(uri));
+  CHECK(!result.net_err);
+  CHECK(result.status == status_type::ok);
+}
+
+TEST_CASE("test coro http basic auth request") {
+  coro_http_client client{};
+  std::string uri = "http://www.baidu.com";
+  client.set_proxy_bearer_token_auth("password");
+  resp_data result = async_simple::coro::syncAwait(client.async_get(uri));
+  CHECK(!result.net_err);
+  CHECK(result.status == status_type::ok);
+}


### PR DESCRIPTION
Lack of means to test connections to proxy servers.
must have proxy server can test it.

![http_client_proxy](https://user-images.githubusercontent.com/20508859/221789714-cb639312-44cf-4b97-be13-2772d17afea4.png)

The following code execution results are as shown above: 

connect to 192.168.102.1 and get baidu.com response.

It's can't use unittest test.

```cpp
TEST_CASE("test coro http proxy request") {
  coro_http_client client{};
  std::string uri = "http://www.baidu.com";
  // Make sure the host and port are matching with your proxy server
  client.set_proxy("192.168.102.1", 7890);
  resp_data result = async_simple::coro::syncAwait(client.async_get(uri));
  CHECK(!result.net_err);
  CHECK(result.status == status_type::ok);
}
```

Digest Authentication not implement because need openssl can implement it.