### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/linux_llvm_cov.yml
+++ b/.github/workflows/linux_llvm_cov.yml
@@ -1,11 +1,6 @@
 name: Ubuntu 22.04 (llvm cov)
 
 on:
-  push:
-    branches:
-      - main
-      - master
-      - cpp20_base
   pull_request_target:
     branches:
       - main


### PR DESCRIPTION
Workflow of llvm coverage should not run when push or merge, because pr does not exist.