### PR TITLE
cmdline flexible with no spaces between options and values

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,12 +3,14 @@ set(project_name test_cinatra)
 add_executable(${project_name}
         test_cinatra.cpp
         test_cinatra_websocket.cpp
+        test_cmdline.cpp
         main.cpp
         )
 target_compile_definitions(${project_name} PRIVATE ASYNC_SIMPLE_HAS_NOT_AIO INJECT_FOR_HTTP_CLIENT_TEST)
 target_include_directories(${project_name} PRIVATE
         ${cinatra_SOURCE_DIR}/thirdparty/asio
         ${cinatra_SOURCE_DIR}/thirdparty/async_simple
+        ${cinatra_SOURCE_DIR}/thirdparty/cmdline
 )
 
 add_test(NAME ${project_name} COMMAND test_cinatra)

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -23,7 +23,7 @@ TEST_CASE("simple test cmd line options") {
 }
 
 // ./cinatra_press_tool -c100 -t4 -d10s --headers=HTTPheaders -r7
-TEST_CASE("test cinatra_press_tool cmd line options") {
+TEST_CASE("test cinatra_press_tool cmd line options without spaces") {
   const char* argv[] = {"cinatra_press_tool",    "-c100", "-vt4", "-d10s",
                         "--headers=HTTPheaders", "-r7"};
   int argc = sizeof(argv) / sizeof(argv[0]);
@@ -57,7 +57,7 @@ TEST_CASE("test cinatra_press_tool cmd line options") {
 }
 
 // ./cinatra_press_tool -c 100 -t 4 -d 10s --headers=HTTPheaders -r 7
-TEST_CASE("test cinatra_press_tool cmd line options") {
+TEST_CASE("test cinatra_press_tool cmd line options with spaces") {
   const char* argv[] = {
       "cinatra_press_tool",    "-c", "100", "-v", "-t", "4", "-d", "10s",
       "--headers=HTTPheaders", "-r", "7"};

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -25,7 +25,42 @@ TEST_CASE("simple test cmd line options") {
 // ./cinatra_press_tool -c100 -t4 -d10s --headers=HTTPheaders -r7
 TEST_CASE("test cinatra_press_tool cmd line options") {
   const char* argv[] = {"cinatra_press_tool",    "-c100", "-vt4", "-d10s",
-                        "--headers=HTTPheaders", "-r",    "7"};
+                        "--headers=HTTPheaders", "-r7"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  cmdline::parser p;
+
+  p.add<int>("connections", 'c',
+             "total number of HTTP connections to keep open with"
+             "                   each thread handling N = connections/threads");
+  p.add<std::string>("duration", 'd', "duration of the test, e.g. 2s, 2m, 2h",
+                     false, "15s");
+  p.add<int>("threads", 't', "total number of threads to use", false, 1);
+  p.add<std::string>(
+      "headers", 'H',
+      "HTTP headers to add to request, e.g. \"User-Agent: coro_http_press\"\n"
+      "            add multiple http headers in a request need to be separated "
+      "by ' && '\n"
+      "            e.g. \"User-Agent: coro_http_press && x-frame-options: "
+      "SAMEORIGIN\"",
+      false, "");
+  p.add<int>("readfix", 'r', "read fixed response", false, 0);
+  p.add("version", 'v', "Display version information");
+
+  p.parse_check(argc, const_cast<char**>(argv));
+
+  CHECK(p.get<int>("connections") == 100);
+  CHECK(p.get<int>("threads") == 4);
+  CHECK(p.get<std::string>("duration") == "10s");
+  CHECK(p.get<std::string>("headers") == "HTTPheaders");
+  CHECK(p.get<int>("readfix") == 7);
+  CHECK(p.exist("version"));
+}
+
+// ./cinatra_press_tool -c 100 -t 4 -d 10s --headers=HTTPheaders -r 7
+TEST_CASE("test cinatra_press_tool cmd line options") {
+  const char* argv[] = {
+      "cinatra_press_tool",    "-c", "100", "-v", "-t", "4", "-d", "10s",
+      "--headers=HTTPheaders", "-r", "7"};
   int argc = sizeof(argv) / sizeof(argv[0]);
   cmdline::parser p;
 

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -5,7 +5,9 @@
 
 // ./simple_test -i input.txt --output=output.txt -vt100
 TEST_CASE("simple test cmd line options") {
-  const char* argv[] = { "simple_test", "-i", "input.txt", "--output=output.txt", "-t4", };
+  const char* argv[] = {
+      "simple_test", "-i", "input.txt", "--output=output.txt", "-t4",
+  };
   int argc = sizeof(argv) / sizeof(argv[0]);
   cmdline::parser p;
 
@@ -13,27 +15,25 @@ TEST_CASE("simple test cmd line options") {
   p.add<std::string>("output", 'o', "output file");
   p.add<int>("threads", 't', "total number of threads to use", false, 1);
 
-  
   p.parse_check(argc, const_cast<char**>(argv));
 
   CHECK(p.get<std::string>("input") == "input.txt");
   CHECK(p.get<std::string>("output") == "output.txt");
   CHECK(p.get<int>("threads") == 4);
-
 }
 
 // ./cinatra_press_tool -c100 -t4 -d10s --headers=HTTPheaders -r7
 TEST_CASE("test cinatra_press_tool cmd line options") {
-  const char* argv[] = { "cinatra_press_tool", "-c100", "-vt4", "-d10s", "--headers=HTTPheaders", "-r7"};
+  const char* argv[] = {"cinatra_press_tool",    "-c100", "-vt4", "-d10s",
+                        "--headers=HTTPheaders", "-r",    "7"};
   int argc = sizeof(argv) / sizeof(argv[0]);
   cmdline::parser p;
 
-  p.add<int>(
-      "connections", 'c',
-      "total number of HTTP connections to keep open with"
-      "                   each thread handling N = connections/threads");
-  p.add<std::string>(
-      "duration", 'd', "duration of the test, e.g. 2s, 2m, 2h", false, "15s");
+  p.add<int>("connections", 'c',
+             "total number of HTTP connections to keep open with"
+             "                   each thread handling N = connections/threads");
+  p.add<std::string>("duration", 'd', "duration of the test, e.g. 2s, 2m, 2h",
+                     false, "15s");
   p.add<int>("threads", 't', "total number of threads to use", false, 1);
   p.add<std::string>(
       "headers", 'H',

--- a/tests/test_cmdline.cpp
+++ b/tests/test_cmdline.cpp
@@ -1,0 +1,57 @@
+#include <string>
+
+#include "cmdline.h"
+#include "doctest.h"
+
+// ./simple_test -i input.txt --output=output.txt -vt100
+TEST_CASE("simple test cmd line options") {
+  const char* argv[] = { "simple_test", "-i", "input.txt", "--output=output.txt", "-t4", };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  cmdline::parser p;
+
+  p.add<std::string>("input", 'i', "input file");
+  p.add<std::string>("output", 'o', "output file");
+  p.add<int>("threads", 't', "total number of threads to use", false, 1);
+
+  
+  p.parse_check(argc, const_cast<char**>(argv));
+
+  CHECK(p.get<std::string>("input") == "input.txt");
+  CHECK(p.get<std::string>("output") == "output.txt");
+  CHECK(p.get<int>("threads") == 4);
+
+}
+
+// ./cinatra_press_tool -c100 -t4 -d10s --headers=HTTPheaders -r7
+TEST_CASE("test cinatra_press_tool cmd line options") {
+  const char* argv[] = { "cinatra_press_tool", "-c100", "-vt4", "-d10s", "--headers=HTTPheaders", "-r7"};
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  cmdline::parser p;
+
+  p.add<int>(
+      "connections", 'c',
+      "total number of HTTP connections to keep open with"
+      "                   each thread handling N = connections/threads");
+  p.add<std::string>(
+      "duration", 'd', "duration of the test, e.g. 2s, 2m, 2h", false, "15s");
+  p.add<int>("threads", 't', "total number of threads to use", false, 1);
+  p.add<std::string>(
+      "headers", 'H',
+      "HTTP headers to add to request, e.g. \"User-Agent: coro_http_press\"\n"
+      "            add multiple http headers in a request need to be separated "
+      "by ' && '\n"
+      "            e.g. \"User-Agent: coro_http_press && x-frame-options: "
+      "SAMEORIGIN\"",
+      false, "");
+  p.add<int>("readfix", 'r', "read fixed response", false, 0);
+  p.add("version", 'v', "Display version information");
+
+  p.parse_check(argc, const_cast<char**>(argv));
+
+  CHECK(p.get<int>("connections") == 100);
+  CHECK(p.get<int>("threads") == 4);
+  CHECK(p.get<std::string>("duration") == "10s");
+  CHECK(p.get<std::string>("headers") == "HTTPheaders");
+  CHECK(p.get<int>("readfix") == 7);
+  CHECK(p.exist("version"));
+}

--- a/thirdparty/cmdline/cmdline.h
+++ b/thirdparty/cmdline/cmdline.h
@@ -470,9 +470,10 @@ class parser {
         if (!argv[i][1])
           continue;
         char last = argv[i][1];
-        bool jump_next = false;   
+        bool jump_next = false;
         for (int j = 2; argv[i][j]; j++) {
-          if (argv[i][j] >= '0' && argv[i][j] <= '9' && options[lookup[last]]->has_value()) {
+          if (argv[i][j] >= '0' && argv[i][j] <= '9' &&
+              options[lookup[last]]->has_value()) {
             set_option(lookup[last], &argv[i][j]);
             jump_next = true;
             break;

--- a/thirdparty/cmdline/cmdline.h
+++ b/thirdparty/cmdline/cmdline.h
@@ -470,7 +470,13 @@ class parser {
         if (!argv[i][1])
           continue;
         char last = argv[i][1];
+        bool jump_next = false;   
         for (int j = 2; argv[i][j]; j++) {
+          if (argv[i][j] >= '0' && argv[i][j] <= '9' && options[lookup[last]]->has_value()) {
+            set_option(lookup[last], &argv[i][j]);
+            jump_next = true;
+            break;
+          }
           last = argv[i][j];
           if (lookup.count(argv[i][j - 1]) == 0) {
             errors.push_back(std::string("undefined short option: -") +
@@ -493,7 +499,9 @@ class parser {
           errors.push_back(std::string("ambiguous short option: -") + last);
           continue;
         }
-
+        if (jump_next) {
+          continue;
+        }
         if (i + 1 < argc && options[lookup[last]]->has_value()) {
           set_option(lookup[last], argv[i + 1]);
           i++;


### PR DESCRIPTION
更加灵活的命令行，**可以删除缩写选项和值的空格**

1. 修改了cmdline.h，支持在缩写选项后面直接添加数字值，
2. 增加了测试程序 tests/test_cmdline.cpp
3. 修改了tests/CMakeLists.txt，把测试单元test_cmdline加入test_cinatra中