### PR TITLE
feat: http client add sni support

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -289,7 +289,7 @@ class coro_http_client {
               socket_->impl_, ssl_ctx_);
       // Set SNI Hostname (many hosts need this to handshake successfully)
       if (!sni_hostname_.empty()) {
-        SSL_set_tlsext_host_name(ssl_stream_.native_handle(),
+        SSL_set_tlsext_host_name(ssl_stream_->native_handle(),
                                  sni_hostname_.c_str());
       }
       use_ssl_ = true;

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -116,6 +116,15 @@ TEST_CASE("test ssl client") {
     CHECK(result.status >= 200);
   }
 }
+
+TEST_CASE("test ssl client") {
+  coro_http_client client{};
+  bool ok = client.init_ssl("../../include/cinatra", "server.crt");
+  REQUIRE_MESSAGE(ok == true, "init ssl fail, please check ssl config");
+  client.set_sni_hostname("https://www.bing.com");
+  auto result = client.get("https://www.bing.com");
+  CHECK(result.status >= 200);
+}
 #endif
 
 async_simple::coro::Lazy<void> test_collect_all() {


### PR DESCRIPTION
when one server with multiple domain, client should support Server Name Indication can connect to server.