### PR TITLE
fix: in aarch64 c++ string_view will cause gibberish's  bug fix

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -24,6 +24,11 @@ else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -pthread -std=c++20")
 endif ()
 
+if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
+    message(STATUS "Build in aarch64")
+    add_definitions(-DCINATRA_AARCH64)
+endif ()
+
 # --------------------- Gcc
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcoroutines")

--- a/include/cinatra/request.hpp
+++ b/include/cinatra/request.hpp
@@ -674,8 +674,11 @@ class request {
       throw std::invalid_argument("not support the value type");
     }
   }
-
+#ifndef CINATRA_AARCH64
   std::string_view get_query_value(std::string_view key) {
+#elif CINATRA_AARCH64
+  std::string get_query_value(std::string_view key) {
+#endif
     if (restful_params_.empty()) {
       auto url = get_url();
       url = url.length() > 1 && url.back() == '/'
@@ -692,22 +695,43 @@ class request {
         if (code_utils::is_url_encode(itf->second)) {
           auto ret = utf8_character_params_.emplace(
               map_key, code_utils::get_string_by_urldecode(itf->second));
+#if CINATRA_AARCH64
+          return std::string(ret.first->second.data(),
+                             ret.first->second.size());
+#else
           return std::string_view(ret.first->second.data(),
                                   ret.first->second.size());
+#endif
         }
+#if CINATRA_AARCH64
+        return std::string(itf->second);
+#else
         return itf->second;
+#endif
       }
       if (code_utils::is_url_encode(it->second)) {
         auto ret = utf8_character_params_.emplace(
             map_key, code_utils::get_string_by_urldecode(it->second));
+#if CINATRA_AARCH64
+        return std::string(ret.first->second.data(), ret.first->second.size());
+#else
         return std::string_view(ret.first->second.data(),
                                 ret.first->second.size());
+#endif
       }
+#if CINATRA_AARCH64
+      return std::string(it->second);
+#else
       return it->second;
+#endif
     }
     else {
       const std::string &result(matches_[restful_params_.at(std::string(key))]);
+#if CINATRA_AARCH64
+      return std::string(result.data(), result.size());
+#else
       return std::string_view(result.data(), result.size());
+#endif
     }
   }
 


### PR DESCRIPTION
No garbled characters after modification,like follow:
![image](https://github.com/qicosmos/cinatra/assets/20508859/97cc7034-abb5-4975-b071-4993769a84ed)

in aarch64,c++ string_view have problem,so I add architecture judge.when architecture is aarch64, use string to replace string_view.
