### PR TITLE
Some improve

### DIFF
--- a/include/cinatra/connection.hpp
+++ b/include/cinatra/connection.hpp
@@ -122,16 +122,18 @@ class connection : public base_connection,
   }
 
   std::string remote_address() {
+    static std::string remote_addr;
     if (has_closed_) {
-      return "";
+      return remote_addr;
     }
 
     std::stringstream ss;
     std::error_code ec;
     ss << socket_.remote_endpoint(ec);
     if (ec) {
-      return "";
+      return remote_addr;
     }
+    remote_addr = ss.str();
     return ss.str();
   }
 

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -877,6 +877,8 @@ class coro_http_client {
           break;
         }
 
+        socket_->impl_.set_option(asio::ip::tcp::no_delay(true));
+
         if (u.is_ssl) {
           if (ec = co_await handle_shake(); ec) {
             break;
@@ -1382,6 +1384,8 @@ class coro_http_client {
           ec) {
         co_return resp_data{ec, 404};
       }
+
+      socket_->impl_.set_option(asio::ip::tcp::no_delay(true));
 
       if (u.is_ssl) {
         if (auto ec = co_await handle_shake(); ec) {

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -300,7 +300,13 @@ class coro_http_client {
   // only make socket connet(or handshake) to the host
   async_simple::coro::Lazy<resp_data> connect(std::string uri) {
     resp_data data{};
-    auto [ok, u] = handle_uri(data, uri);
+    bool no_schema = !has_schema(uri);
+    std::string append_uri;
+    if (no_schema) {
+      append_uri.append("http://").append(uri);
+    }
+
+    auto [ok, u] = handle_uri(data, no_schema ? append_uri : uri);
     if (!ok) {
       co_return resp_data{{}, 404};
     }
@@ -1634,10 +1640,10 @@ class coro_http_client {
 
   template <typename S>
   bool has_schema(const S &url) {
-    size_t pos_http = url.find_first_of("http://");
-    size_t pos_https = url.find_first_of("https://");
-    size_t pos_ws = url.find_first_of("ws://");
-    size_t pos_wss = url.find_first_of("wss://");
+    size_t pos_http = url.find("http://");
+    size_t pos_https = url.find("https://");
+    size_t pos_ws = url.find("ws://");
+    size_t pos_wss = url.find("wss://");
     bool has_http_scheme =
         ((pos_http != std::string::npos) && pos_http == 0) ||
         ((pos_https != std::string::npos) && pos_https == 0) ||

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -854,10 +854,11 @@ class coro_http_client {
 
     do {
       uri_t u;
+      std::string append_uri;
 
       if (socket_->has_closed_ || (!uri.empty() && uri[0] != '/')) {
         bool no_schema = !has_schema(uri);
-        std::string append_uri;
+
         if (no_schema) {
           append_uri.append("http://").append(uri);
         }

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -170,6 +170,7 @@ TEST_CASE("test coro_http_client connect/request timeout") {
     client.init_config(conf);
     auto r =
         async_simple::coro::syncAwait(client.async_get("http://www.baidu.com"));
+    std::cout << r.net_err.value() << ", " << r.net_err.message() << "\n";
     bool ret = (r.net_err == std::errc::timed_out ||
                 r.net_err == asio::error::operation_aborted);
     CHECK(ret);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -150,6 +150,19 @@ async_simple::coro::Lazy<void> test_collect_all() {
   thd.join();
 }
 
+TEST_CASE("test pass path not entire uri") {
+  coro_http_client client{};
+  auto r =
+      async_simple::coro::syncAwait(client.async_get("http://www.baidu.com"));
+  CHECK(r.status >= 200);
+
+  r = async_simple::coro::syncAwait(client.async_get("http://www.baidu.com"));
+  CHECK(r.status >= 200);
+
+  r = async_simple::coro::syncAwait(client.async_get("/"));
+  CHECK(r.status >= 200);
+}
+
 TEST_CASE("test coro_http_client connect/request timeout") {
   {
     coro_http_client client{};

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -170,7 +170,9 @@ TEST_CASE("test coro_http_client connect/request timeout") {
     client.init_config(conf);
     auto r =
         async_simple::coro::syncAwait(client.async_get("http://www.baidu.com"));
-    CHECK(r.net_err == std::errc::timed_out);
+    bool ret = (r.net_err == std::errc::timed_out ||
+                r.net_err == asio::error::operation_aborted);
+    CHECK(ret);
   }
 
   {


### PR DESCRIPTION
improvement:
```c++
coro_http_client client;
client.get("purecpp.cn");
client.get("/"); // it's also ok.
```

or

```c++
coro_http_client client;
co_await client.connect("purecpp.cn");
co_await client.async_get("/");
```