### PR TITLE
optimize header parse by zero-copy

### DIFF
--- a/include/cinatra/cinatra_log_wrapper.hpp
+++ b/include/cinatra/cinatra_log_wrapper.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include <iostream>
 namespace cinatra {
 struct null_logger_t {

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1710,8 +1710,7 @@ class coro_http_client {
     return has_http_scheme;
   }
 
-  http_parser parser;
-
+  http_parser parser_;
   coro_io::ExecutorWrapper<> executor_wrapper_;
   coro_io::period_timer timer_;
   std::shared_ptr<socket_t> socket_;

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1237,7 +1237,7 @@ class coro_http_client {
         break;
       }
 
-      ec = handle_header(data, parser, size);
+      ec = handle_header(data, parser_, size);
 #ifdef INJECT_FOR_HTTP_CLIENT_TEST
       if (inject_header_valid == ClientInjectAction::header_error) {
         ec = std::make_error_code(std::errc::protocol_error);
@@ -1250,32 +1250,32 @@ class coro_http_client {
         break;
       }
 
-      is_keep_alive = parser.keep_alive();
+      is_keep_alive = parser_.keep_alive();
       if (method == http_method::HEAD) {
         co_return data;
       }
 
-      bool is_ranges = parser.is_ranges();
+      bool is_ranges = parser_.is_ranges();
       if (is_ranges) {
         is_keep_alive = true;
       }
-      if (parser.is_chunked()) {
+      if (parser_.is_chunked()) {
         is_keep_alive = true;
         ec = co_await handle_chunked(data, std::move(ctx));
         break;
       }
 
       redirect_uri_.clear();
-      bool is_redirect = parser.is_location();
+      bool is_redirect = parser_.is_location();
       if (is_redirect)
-        redirect_uri_ = parser.get_header_value("Location");
+        redirect_uri_ = parser_.get_header_value("Location");
 
-      size_t content_len = (size_t)parser.body_len();
+      size_t content_len = (size_t)parser_.body_len();
 #ifdef BENCHMARK_TEST
-      total_len_ = parser.total_len();
+      total_len_ = parser_.total_len();
 #endif
 
-      if ((size_t)parser.body_len() <= read_buf_.size()) {
+      if ((size_t)parser_.body_len() <= read_buf_.size()) {
         // Now get entire content, additional data will discard.
         // copy body.
         if (content_len > 0) {

--- a/include/cinatra/http_parser.hpp
+++ b/include/cinatra/http_parser.hpp
@@ -12,7 +12,7 @@
 using namespace std::string_view_literals;
 
 #ifndef CINATRA_MAX_HTTP_HEADER_FIELD_SIZE
-#define CINATRA_MAX_HTTP_HEADER_FIELD_SIZE 200
+#define CINATRA_MAX_HTTP_HEADER_FIELD_SIZE 100
 #endif
 
 namespace cinatra {
@@ -49,7 +49,7 @@ class http_parser {
 
   std::string_view get_header_value(std::string_view key) const {
     for (size_t i = 0; i < num_headers_; i++) {
-      if (iequal(headers_[i].name,key))
+      if (iequal(headers_[i].name, key))
         return headers_[i].value;
     }
     return {};
@@ -95,7 +95,7 @@ class http_parser {
   int total_len() const { return header_len_ + body_len_; }
 
   bool is_location() {
-    auto location = this->get_header_value("Location");
+    auto location = this->get_header_value("Location"sv);
     return !location.empty();
   }
 

--- a/include/cinatra/http_parser.hpp
+++ b/include/cinatra/http_parser.hpp
@@ -1,12 +1,19 @@
 #pragma once
+#include <algorithm>
+#include <array>
 #include <cctype>
+#include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
+#include "cinatra_log_wrapper.hpp"
 #include "picohttpparser.h"
 
 using namespace std::string_view_literals;
+
+#ifndef CINATRA_MAX_HTTP_HEADER_FIELD_SIZE
+#define CINATRA_MAX_HTTP_HEADER_FIELD_SIZE 200
+#endif
 
 namespace cinatra {
 class http_parser {
@@ -14,35 +21,42 @@ class http_parser {
   int parse_response(const char *data, size_t size, int last_len) {
     int minor_version;
 
-    num_headers_ = sizeof(headers_) / sizeof(headers_[0]);
+    num_headers_ = CINATRA_MAX_HTTP_HEADER_FIELD_SIZE;
     const char *msg;
     size_t msg_len;
-    header_len_ =
-        phr_parse_response(data, size, &minor_version, &status_, &msg, &msg_len,
-                           headers_, &num_headers_, last_len);
+    header_len_ = cinatra::detail::phr_parse_response(
+        data, size, &minor_version, &status_, &msg, &msg_len, headers_.data(),
+        &num_headers_, last_len);
     msg_ = {msg, msg_len};
-    auto header_value = this->get_header_value("content-length");
+    auto header_value = this->get_header_value("content-length"sv);
     if (header_value.empty()) {
       body_len_ = 0;
     }
     else {
       body_len_ = atoi(header_value.data());
     }
-
+    if (header_len_ < 0) [[unlikely]] {
+      CINATRA_LOG_WARNING << "parse http head failed";
+      if (size == CINATRA_MAX_HTTP_HEADER_FIELD_SIZE) {
+        CINATRA_LOG_ERROR << "the field of http head is out of max limit "
+                          << CINATRA_MAX_HTTP_HEADER_FIELD_SIZE
+                          << ", you can define macro "
+                             "CINATRA_MAX_HTTP_HEADER_FIELD_SIZE to expand it.";
+      }
+    }
     return header_len_;
   }
 
   std::string_view get_header_value(std::string_view key) const {
     for (size_t i = 0; i < num_headers_; i++) {
-      if (iequal(headers_[i].name, headers_[i].name_len, key.data()))
-        return std::string_view(headers_[i].value, headers_[i].value_len);
+      if (iequal(headers_[i].name,key))
+        return headers_[i].value;
     }
-
     return {};
   }
 
   bool is_chunked() const {
-    auto transfer_encoding = this->get_header_value("transfer-encoding");
+    auto transfer_encoding = this->get_header_value("transfer-encoding"sv);
     if (transfer_encoding == "chunked"sv) {
       return true;
     }
@@ -51,12 +65,12 @@ class http_parser {
   }
 
   bool is_ranges() const {
-    auto transfer_encoding = this->get_header_value("Accept-Ranges");
+    auto transfer_encoding = this->get_header_value("Accept-Ranges"sv);
     return !transfer_encoding.empty();
   }
 
   bool is_websocket() const {
-    auto upgrade = this->get_header_value("Upgrade");
+    auto upgrade = this->get_header_value("Upgrade"sv);
     return upgrade == "WebSocket"sv || upgrade == "websocket"sv;
   }
 
@@ -64,8 +78,8 @@ class http_parser {
     if (is_websocket()) {
       return true;
     }
-    auto val = this->get_header_value("connection");
-    if (val.empty() || iequal(val.data(), val.length(), "keep-alive")) {
+    auto val = this->get_header_value("connection"sv);
+    if (val.empty() || iequal(val, "keep-alive"sv)) {
       return true;
     }
 
@@ -87,42 +101,16 @@ class http_parser {
 
   std::string_view msg() const { return msg_; }
 
-  std::pair<phr_header *, size_t> get_headers() {
-    return {headers_, num_headers_};
-  }
-
-  void set_headers(
-      const std::vector<std::pair<std::string, std::string>> &headers) {
-    num_headers_ = headers.size();
-    for (size_t i = 0; i < num_headers_; i++) {
-      headers_[i].name = headers[i].first.data();
-      headers_[i].name_len = headers[i].first.size();
-      headers_[i].value = headers[i].second.data();
-      headers_[i].value_len = headers[i].second.size();
-    }
+  std::span<http_header> get_headers() {
+    return {headers_.data(), num_headers_};
   }
 
  private:
-  std::string_view get_header_value(phr_header *headers, size_t num_headers,
-                                    std::string_view key) {
-    for (size_t i = 0; i < num_headers; i++) {
-      if (iequal(headers[i].name, headers[i].name_len, key.data()))
-        return std::string_view(headers[i].value, headers[i].value_len);
-    }
-
-    return {};
-  }
-
-  bool iequal(const char *s, size_t l, const char *t) const {
-    if (strlen(t) != l)
-      return false;
-
-    for (size_t i = 0; i < l; i++) {
-      if (std::tolower(s[i]) != std::tolower(t[i]))
-        return false;
-    }
-
-    return true;
+  bool iequal(std::string_view a, std::string_view b) const {
+    return std::equal(a.begin(), a.end(), b.begin(), b.end(),
+                      [](char a, char b) {
+                        return tolower(a) == tolower(b);
+                      });
   }
 
   int status_ = 0;
@@ -130,6 +118,6 @@ class http_parser {
   size_t num_headers_ = 0;
   int header_len_ = 0;
   int body_len_ = 0;
-  struct phr_header headers_[100];
+  std::array<http_header, CINATRA_MAX_HTTP_HEADER_FIELD_SIZE> headers_;
 };
 }  // namespace cinatra

--- a/include/cinatra/picohttpparser.h
+++ b/include/cinatra/picohttpparser.h
@@ -30,38 +30,21 @@
 #include <stddef.h>
 #include <string.h>
 
-#ifdef CINATRA_SSE
-#ifdef _MSC_VER
-#include <nmmintrin.h>
-#else
-#include <x86intrin.h>
-#endif
-#endif
-
-#ifdef CINATRA_AVX2
-#include <immintrin.h>
-#endif
-
-#include <sys/types.h>
+#include <string_view>
 
 #ifdef _MSC_VER
 #define ssize_t intptr_t
 #endif
 
-/* $Id: 67fd3ee74103ada60258d8a16e868f483abcca87 $ */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace cinatra {
+struct http_header {
+  std::string_view name;
+  std::string_view value;
+};
+namespace detail {
 
 /* contains name and value of a header (name == NULL if is a continuing line
  * of a multiline header */
-struct phr_header {
-  const char *name;
-  size_t name_len;
-  const char *value;
-  size_t value_len;
-};
 
 /* returns number of bytes consumed if successful, -2 if request is partial,
  * -1 if failed */
@@ -177,31 +160,10 @@ static const char *findchar_fast(const char *buf, const char *buf_end,
                                  const char *ranges, int ranges_size,
                                  int *found) {
   *found = 0;
-#ifdef CINATRA_SSE
-  if (likely(buf_end - buf >= 16)) {
-    __m128i ranges16 = _mm_loadu_si128((const __m128i *)ranges);
-
-    size_t left = (buf_end - buf) & ~15;
-    do {
-      __m128i b16 = _mm_loadu_si128((const __m128i *)buf);
-      int r = _mm_cmpestri(
-          ranges16, ranges_size, b16, 16,
-          _SIDD_LEAST_SIGNIFICANT | _SIDD_CMP_RANGES | _SIDD_UBYTE_OPS);
-      if (unlikely(r != 16)) {
-        buf += r;
-        *found = 1;
-        break;
-      }
-      buf += 16;
-      left -= 16;
-    } while (likely(left != 0));
-  }
-#else
   /* suppress unused parameter warning */
   (void)buf_end;
   (void)ranges;
   (void)ranges_size;
-#endif
   return buf;
 }
 
@@ -209,20 +171,7 @@ static const char *get_token_to_eol(const char *buf, const char *buf_end,
                                     const char **token, size_t *token_len,
                                     int *ret) {
   const char *token_start = buf;
-#ifdef CINATRA_SSE
-  static const char ranges1[] =
-      "\0\010"
-      /* allow HT */
-      "\012\037"
-      /* allow SP and up to but not including DEL */
-      "\177\177"
-      /* allow chars w. MSB set */
-      ;
-  int found;
-  buf = findchar_fast(buf, buf_end, ranges1, sizeof(ranges1) - 1, &found);
-  if (found)
-    goto FOUND_CTL;
-#else
+
   /* find non-printable char within the next 8 bytes, this is the hottest code;
    * manually inlined */
   while (likely(buf_end - buf >= 8)) {
@@ -249,7 +198,7 @@ static const char *get_token_to_eol(const char *buf, const char *buf_end,
     }
     ++buf;
   }
-#endif
+
   for (;; ++buf) {
     CHECK_EOF();
     if (unlikely(!IS_PRINTABLE_ASCII(*buf))) {
@@ -346,348 +295,14 @@ static const char *parse_http_version(const char *buf, const char *buf_end,
   return buf;
 }
 
-#ifdef CINATRA_AVX2
-static unsigned long TZCNT(unsigned long long in) {
-  unsigned long res;
-  asm("tzcnt %1, %0\n\t" : "=r"(res) : "r"(in));
-  return res;
-}
-/* Parse only 32 bytes */
-static void find_ranges32(__m256i b0, unsigned long *range0,
-                          unsigned long *range1) {
-  const __m256i rr0 = _mm256_set1_epi8(0x00 - 1);
-  const __m256i rr1 = _mm256_set1_epi8(0x1f + 1);
-  const __m256i rr2 = _mm256_set1_epi8(0x3a);
-  const __m256i rr4 = _mm256_set1_epi8(0x7f);
-  const __m256i rr7 = _mm256_set1_epi8(0x09);
-
-  /* 0<=x */
-  __m256i gz0 = _mm256_cmpgt_epi8(b0, rr0);
-  /* 0=<x<=1f */
-  __m256i z_1f_0 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b0), gz0);
-  /* 0<=x<=1f || x==3a */
-  __m256i range0_0 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b0), z_1f_0);
-  /* 0<=x<9 || 9<x<=1f || x==7f */
-  __m256i range1_0 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b0),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b0, rr7), z_1f_0));
-  /* Generate bit masks */
-  unsigned int r0 = _mm256_movemask_epi8(range0_0);
-  /* Combine 32bit masks into a single 64bit mask */
-  *range0 = r0;
-  r0 = _mm256_movemask_epi8(range1_0);
-  *range1 = r0;
-}
-
-/* Parse only 64 bytes */
-static void find_ranges64(__m256i b0, __m256i b1, unsigned long *range0,
-                          unsigned long *range1) {
-  const __m256i rr0 = _mm256_set1_epi8(0x00 - 1);
-  const __m256i rr1 = _mm256_set1_epi8(0x1f + 1);
-  const __m256i rr2 = _mm256_set1_epi8(0x3a);
-  const __m256i rr4 = _mm256_set1_epi8(0x7f);
-  const __m256i rr7 = _mm256_set1_epi8(0x09);
-
-  /* 0<=x */
-  __m256i gz0 = _mm256_cmpgt_epi8(b0, rr0);
-  __m256i gz1 = _mm256_cmpgt_epi8(b1, rr0);
-  /* 0=<x<=1f */
-  __m256i z_1f_0 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b0), gz0);
-  __m256i z_1f_1 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b1), gz1);
-  /* 0<=x<=1f || x==3a */
-  __m256i range0_0 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b0), z_1f_0);
-  __m256i range0_1 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b1), z_1f_1);
-  /* 0<=x<9 || 9<x<=1f || x==7f */
-  __m256i range1_0 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b0),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b0, rr7), z_1f_0));
-  __m256i range1_1 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b1),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b1, rr7), z_1f_1));
-  /* Generate bit masks */
-  unsigned int r0 = _mm256_movemask_epi8(range0_0);
-  unsigned int r1 = _mm256_movemask_epi8(range0_1);
-  /* Combine 32bit masks into a single 64bit mask */
-  *range0 = r0 ^ ((unsigned long)r1 << 32);
-  r0 = _mm256_movemask_epi8(range1_0);
-  r1 = _mm256_movemask_epi8(range1_1);
-  *range1 = r0 ^ ((unsigned long)r1 << 32);
-}
-
-/* This function parses 128 bytes at a time, creating bitmap of all interesting
- * tokens */
-static void find_ranges(const char *buf, const char *buf_end,
-                        unsigned long *range0, unsigned long *range1) {
-  const __m256i rr0 = _mm256_set1_epi8(0x00 - 1);
-  const __m256i rr1 = _mm256_set1_epi8(0x1f + 1);
-  const __m256i rr2 = _mm256_set1_epi8(0x3a);
-  const __m256i rr4 = _mm256_set1_epi8(0x7f);
-  const __m256i rr7 = _mm256_set1_epi8(0x09);
-
-  __m256i b0, b1, b2, b3;
-  unsigned char tmpbuf[32];
-  int i;
-  int dist;
-
-  if ((dist = buf_end - buf) < 128) {
-    // memcpy(tmpbuf, buf + (dist & (-32)), dist & 31);
-    for (i = 0; i < (dist & 31); i++) tmpbuf[i] = buf[(dist & (-32)) + i];
-    if (dist >= 96) {
-      b0 = _mm256_loadu_si256((void *)buf + 32 * 0);
-      b1 = _mm256_loadu_si256((void *)buf + 32 * 1);
-      b2 = _mm256_loadu_si256((void *)buf + 32 * 2);
-      b3 = _mm256_loadu_si256((void *)tmpbuf);
-    }
-    else if (dist >= 64) {
-      b0 = _mm256_loadu_si256((void *)buf + 32 * 0);
-      b1 = _mm256_loadu_si256((void *)buf + 32 * 1);
-      b2 = _mm256_loadu_si256((void *)tmpbuf);
-      b3 = _mm256_setzero_si256();
-    }
-    else {
-      if (dist < 32) {
-        b0 = _mm256_loadu_si256((void *)tmpbuf);
-        return find_ranges32(b0, range0, range1);
-      }
-      else {
-        b0 = _mm256_loadu_si256((void *)buf + 32 * 0);
-        b1 = _mm256_loadu_si256((void *)tmpbuf);
-        return find_ranges64(b0, b1, range0, range1);
-      }
-    }
-  }
-  else {
-    /* Load 128 bytes */
-    b0 = _mm256_loadu_si256((void *)buf + 32 * 0);
-    b1 = _mm256_loadu_si256((void *)buf + 32 * 1);
-    b2 = _mm256_loadu_si256((void *)buf + 32 * 2);
-    b3 = _mm256_loadu_si256((void *)buf + 32 * 3);
-  }
-
-  /* 0<=x */
-  __m256i gz0 = _mm256_cmpgt_epi8(b0, rr0);
-  __m256i gz1 = _mm256_cmpgt_epi8(b1, rr0);
-  __m256i gz2 = _mm256_cmpgt_epi8(b2, rr0);
-  __m256i gz3 = _mm256_cmpgt_epi8(b3, rr0);
-  /* 0=<x<=1f */
-  __m256i z_1f_0 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b0), gz0);
-  __m256i z_1f_1 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b1), gz1);
-  __m256i z_1f_2 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b2), gz2);
-  __m256i z_1f_3 = _mm256_and_si256(_mm256_cmpgt_epi8(rr1, b3), gz3);
-  /* 0<=x<=1f || x==3a */
-  __m256i range0_0 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b0), z_1f_0);
-  __m256i range0_1 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b1), z_1f_1);
-  __m256i range0_2 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b2), z_1f_2);
-  __m256i range0_3 = _mm256_or_si256(_mm256_cmpeq_epi8(rr2, b3), z_1f_3);
-  /* 0<=x<9 || 9<x<=1f || x==7f */
-  __m256i range1_0 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b0),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b0, rr7), z_1f_0));
-  __m256i range1_1 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b1),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b1, rr7), z_1f_1));
-  __m256i range1_2 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b2),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b2, rr7), z_1f_2));
-  __m256i range1_3 =
-      _mm256_or_si256(_mm256_cmpeq_epi8(rr4, b3),
-                      _mm256_andnot_si256(_mm256_cmpeq_epi8(b3, rr7), z_1f_3));
-  /* Generate bit masks */
-  unsigned int r0 = _mm256_movemask_epi8(range0_0);
-  unsigned int r1 = _mm256_movemask_epi8(range0_1);
-  /* Combine 32bit masks into a single 64bit mask */
-  *range0 = r0 ^ ((unsigned long)r1 << 32);
-
-  r0 = _mm256_movemask_epi8(range0_2);
-  r1 = _mm256_movemask_epi8(range0_3);
-  range0[1] = r0 ^ ((unsigned long)r1 << 32);
-
-  r0 = _mm256_movemask_epi8(range1_0);
-  r1 = _mm256_movemask_epi8(range1_1);
-
-  *range1 = r0 ^ ((unsigned long)r1 << 32);
-  r0 = _mm256_movemask_epi8(range1_2);
-  r1 = _mm256_movemask_epi8(range1_3);
-
-  range1[1] = r0 ^ ((unsigned long)r1 << 32);
-}
-
 static const char *parse_headers(const char *buf, const char *buf_end,
-                                 struct phr_header *headers,
-                                 size_t *num_headers, size_t max_headers,
-                                 int *ret) {
-  /* Bitmap for the first type of tokens */
-  unsigned long rr0[2] = {0};
-  /* Bitmap for the second type of tokens */
-  unsigned long rr1[2] = {0};
-  /* Pointer to the start of the currently parsed block of 128 bytes */
-  const char *prep_start = NULL;
-  int found;
-  int n_headers = *num_headers;
-
-  for (;; ++n_headers) {
-    CHECK_EOF();
-    if (*buf == '\015') {
-      ++buf;
-      EXPECT_CHAR('\012');
-      break;
-    }
-    else if (*buf == '\012') {
-      ++buf;
-      break;
-    }
-    if (n_headers == max_headers) {
-      *ret = -1;
-      *num_headers = n_headers;
-      return NULL;
-    }
-
-    if (!(n_headers != 0 && (*buf == ' ' || *buf == '\t')) &&
-        !(*buf >= 65 && *buf <= 90)) {
-      if (!token_char_map[(unsigned char)*buf]) {
-        *ret = -1;
-        *num_headers = n_headers;
-        return NULL;
-      }
-      headers[n_headers].name = buf;
-
-      /* Attempt to find a match in the index */
-      found = 0;
-      do {
-        unsigned long distance = buf - prep_start;
-        /* Check if the bitmaps are still valid. An assumption I make is that
-           buf > 128 (i.e. the os will never allocate memory at address 0-128 */
-        if (unlikely(distance >=
-                     128)) { /* Bitmaps are too old, make new ones */
-          prep_start = buf;
-          distance = 0;
-          find_ranges(buf, buf_end, rr0, rr1);
-        }
-        else if (distance >= 64) { /* In the second half of the bitmap */
-          unsigned long index =
-              rr0[1] >> (distance - 64);     /* Correct offset of the bitmap */
-          unsigned long find = TZCNT(index); /* Fine next set bit */
-          if ((find < 64)) {                 /* Yey, we found a token */
-            buf += find;
-            found = 1;
-            break;
-          }
-          buf = prep_start + 128; /* No token was found in the current bitmap */
-          continue;
-        }
-        unsigned long index =
-            rr0[0] >> (distance);          /* In the first half of the bitmap */
-        unsigned long find = TZCNT(index); /* Find next set bit */
-        if ((find < 64)) {                 /* Token found */
-          buf += find;
-          found = 1;
-          break;
-        } /* Token not found, look at second half of bitmap */
-        index = rr0[1];
-        find = TZCNT(index);
-        if ((find < 64)) {
-          buf += 64 + find - distance;
-          found = 1;
-          break;
-        }
-
-        buf = prep_start + 128;
-      } while (buf < buf_end);
-
-      if (!found)
-        if (buf >= buf_end) {
-          *ret = -2;
-          *num_headers = n_headers;
-          return NULL;
-        }
-      headers[n_headers].name_len = buf - headers[n_headers].name;
-      ++buf;
-      CHECK_EOF();
-      while ((*buf == ' ' || *buf == '\t')) {
-        ++buf;
-        CHECK_EOF();
-      }
-    }
-    else {
-      headers[n_headers].name = NULL;
-      headers[n_headers].name_len = 0;
-    }
-    const char *token_start = buf;
-
-    found = 0;
-
-    do {
-      /* Too far */
-      unsigned long distance = buf - prep_start; /* Same algorithm as above */
-      if (unlikely(distance >= 128)) {
-        prep_start = buf;
-        distance = 0;
-        find_ranges(buf, buf_end, rr0, rr1);
-      }
-      else if (distance >= 64) {
-        unsigned long index = rr1[1] >> (distance - 64);
-        unsigned long find = TZCNT(index);
-        if ((find < 64)) {
-          buf += find;
-          found = 1;
-          break;
-        }
-        buf = prep_start + 128;
-        continue;
-      }
-      unsigned long index = rr1[0] >> (distance);
-      unsigned long find = TZCNT(index);
-      if ((find < 64)) {
-        buf += find;
-        found = 1;
-        break;
-      }
-      index = rr1[1];
-      find = TZCNT(index);
-      if ((find < 64)) {
-        buf += 64 + find - distance;
-        found = 1;
-        break;
-      }
-
-      buf = prep_start + 128;
-    } while (buf < buf_end);
-
-    if (!found)
-      if (buf >= buf_end) {
-        *ret = -2;
-        *num_headers = n_headers;
-        return NULL;
-      }
-
-    unsigned short two_char = *(unsigned short *)buf;
-
-    if (likely(two_char == 0x0a0d)) {
-      headers[n_headers].value_len = buf - token_start;
-      buf += 2;
-    }
-    else if (unlikely(two_char & 0x0a == 0x0a)) {
-      headers[n_headers].value_len = buf - token_start;
-      ++buf;
-    }
-    else {
-      *ret = -1;
-      *num_headers = n_headers;
-      return NULL;
-    }
-    headers[n_headers].value = token_start;
-  }
-  *num_headers = n_headers;
-  return buf;
-}
-
-#else
-
-static const char *parse_headers(const char *buf, const char *buf_end,
-                                 struct phr_header *headers,
-                                 size_t *num_headers, size_t max_headers,
-                                 int *ret) {
+                                 http_header *headers, size_t *num_headers,
+                                 size_t max_headers, int *ret) {
   for (;; ++*num_headers) {
+    const char *name;
+    size_t name_len;
+    const char *value;
+    size_t value_len;
     CHECK_EOF();
     if (*buf == '\015') {
       ++buf;
@@ -705,7 +320,7 @@ static const char *parse_headers(const char *buf, const char *buf_end,
     if (!(*num_headers != 0 && (*buf == ' ' || *buf == '\t'))) {
       /* parsing name, but do not discard SP before colon, see
        * http://www.mozilla.org/security/announce/2006/mfsa2006-33.html */
-      headers[*num_headers].name = buf;
+      name = buf;
       static const char ALIGNED(16) ranges1[] =
           "\x00 "  /* control chars and up to SP */
           "\"\""   /* 0x22 */
@@ -731,8 +346,7 @@ static const char *parse_headers(const char *buf, const char *buf_end,
         ++buf;
         CHECK_EOF();
       }
-      if ((headers[*num_headers].name_len = buf - headers[*num_headers].name) ==
-          0) {
+      if ((name_len = buf - name) == 0) {
         *ret = -1;
         return NULL;
       }
@@ -745,24 +359,23 @@ static const char *parse_headers(const char *buf, const char *buf_end,
       }
     }
     else {
-      headers[*num_headers].name = NULL;
-      headers[*num_headers].name_len = 0;
+      name = NULL;
+      name_len = 0;
     }
-    if ((buf = get_token_to_eol(buf, buf_end, &headers[*num_headers].value,
-                                &headers[*num_headers].value_len, ret)) ==
+    if ((buf = get_token_to_eol(buf, buf_end, &value, &value_len, ret)) ==
         NULL) {
       return NULL;
     }
+    headers[*num_headers] = {std::string_view{name, name_len},
+                             std::string_view{value, value_len}};
   }
   return buf;
 }
 
-#endif
-
 static const char *parse_request(const char *buf, const char *buf_end,
                                  const char **method, size_t *method_len,
                                  const char **path, size_t *path_len,
-                                 int *minor_version, struct phr_header *headers,
+                                 int *minor_version, http_header *headers,
                                  size_t *num_headers, size_t max_headers,
                                  int *ret) {
   /* skip first empty line (some clients add CRLF after POST content) */
@@ -801,7 +414,7 @@ static const char *parse_request(const char *buf, const char *buf_end,
 inline int phr_parse_request(const char *buf_start, size_t len,
                              const char **method, size_t *method_len,
                              const char **path, size_t *path_len,
-                             int *minor_version, struct phr_header *headers,
+                             int *minor_version, http_header *headers,
                              size_t *num_headers, size_t last_len) {
   const char *buf = buf_start, *buf_end = buf_start + len;
   size_t max_headers = *num_headers;
@@ -832,9 +445,8 @@ inline int phr_parse_request(const char *buf_start, size_t len,
 inline const char *parse_response(const char *buf, const char *buf_end,
                                   int *minor_version, int *status,
                                   const char **msg, size_t *msg_len,
-                                  struct phr_header *headers,
-                                  size_t *num_headers, size_t max_headers,
-                                  int *ret) {
+                                  http_header *headers, size_t *num_headers,
+                                  size_t max_headers, int *ret) {
   /* parse "HTTP/1.x" */
   if ((buf = parse_http_version(buf, buf_end, minor_version, ret)) == NULL) {
     return NULL;
@@ -867,7 +479,7 @@ inline const char *parse_response(const char *buf, const char *buf_end,
 
 inline int phr_parse_response(const char *buf_start, size_t len,
                               int *minor_version, int *status, const char **msg,
-                              size_t *msg_len, struct phr_header *headers,
+                              size_t *msg_len, http_header *headers,
                               size_t *num_headers, size_t last_len) {
   const char *buf = buf_start, *buf_end = buf + len;
   size_t max_headers = *num_headers;
@@ -894,7 +506,7 @@ inline int phr_parse_response(const char *buf_start, size_t len,
 }
 
 inline int phr_parse_headers(const char *buf_start, size_t len,
-                             struct phr_header *headers, size_t *num_headers,
+                             http_header *headers, size_t *num_headers,
                              size_t last_len) {
   const char *buf = buf_start, *buf_end = buf + len;
   size_t max_headers = *num_headers;
@@ -1059,13 +671,10 @@ Exit:
 inline int phr_decode_chunked_is_in_data(struct phr_chunked_decoder *decoder) {
   return decoder->_state == CHUNKED_IN_CHUNK_DATA;
 }
-
+}  // namespace detail
+}  // namespace cinatra
 #undef CHECK_EOF
 #undef EXPECT_CHAR
 #undef ADVANCE_TOKEN
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif

--- a/include/cinatra/utils.hpp
+++ b/include/cinatra/utils.hpp
@@ -353,6 +353,12 @@ inline bool iequal(const char *s, size_t l, const char *t, size_t size) {
   return true;
 }
 
+inline bool iequal(std::string_view a, std::string_view b) {
+  return std::equal(a.begin(), a.end(), b.begin(), b.end(), [](char a, char b) {
+    return tolower(a) == tolower(b);
+  });
+}
+
 template <typename T>
 inline bool find_strIC(const T &src, const T &dest) {
   auto it = std::search(src.begin(), src.end(), dest.begin(), dest.end(),


### PR DESCRIPTION
The http response will copy the header as string, which cause program call malloc frequently.

This pr use std::string_view & span to avoid it.