### PR TITLE
feat: add the function to easily create http download servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ CMakeUserPresets.json
 .DS_Store
 node_modules
 /CMakeSettings.json
+!cmake/build.cmake

--- a/README.md
+++ b/README.md
@@ -246,6 +246,20 @@ cinatra目前支持了multipart和octet-stream格式的上传。
 	//chunked download
 	//cinatra will send you the file, if the file is big file(more than 5M) the file will be downloaded by chunked. support continues download
 
+	同时可以使用set_http_file_server(std::string path);函数来将cinatra转换为一个http文件下载服务器，path为该文件服务器的路径。示例如下:
+
+	#include "cinatra.hpp"
+	using namespace cinatra;
+
+	int main() {
+		http_server server(std::thread::hardware_concurrency());
+		server.set_http_file_server("http_file_server");
+		server.listen("0.0.0.0", "8080");
+		// 略
+	}
+
+	此时访问当前服务器的`http_file_server`路径时会在浏览器展示所有可下载文件，点击即可下载。
+
 ## 示例6：websocket
 
 	#include "cinatra.hpp"

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -242,6 +242,7 @@ int main() {
   // test_ssl_server();
   // test_download();
   http_server server(std::thread::hardware_concurrency());
+  server.set_http_file_server("http_download_file_server");
   bool r = server.listen("0.0.0.0", "8090");
   if (!r) {
     // LOG_INFO << "listen failed";

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -601,6 +601,29 @@ class http_server_ : private noncopyable {
     }
   }
 
+  int get_static_dir_filenames(const std::string &dir,
+                               std::vector<std::string> &filenames,
+                               size_t dir_name_length) {
+    fs::path path(dir);
+    if (!fs::exists(path))
+      return -1;
+    fs::directory_iterator end_iter;
+    for (fs::directory_iterator iter(path); iter != end_iter; ++iter) {
+      if (fs::is_directory(iter->status())) {
+        get_static_dir_filenames(iter->path().string(), filenames,
+                                 dir_name_length);
+      }
+      else {
+        auto u8_path_name = iter->path().u8string();
+        std::string relative_path(u8_path_name.begin(), u8_path_name.end());
+        size_t length = relative_path.length();
+        relative_path = relative_path.substr(dir_name_length + 1, length);
+        filenames.push_back(relative_path);
+      }
+    }
+    return filenames.size();
+  }
+
   bool build_http_download_lists_response(request &req,
                                           std::string &&resp_str) {
     std::string res_str = "";
@@ -608,17 +631,13 @@ class http_server_ : private noncopyable {
                                std::string(req.get_header_value("host")) + "/";
     std::string href_of_tail = "\"target=\"_blank\">";
     if (req.get_res_path() == download_display_file_dir_) {
-      std::string file_dir_str = static_dir_;
-      std::filesystem::path dir_path(file_dir_str);
-
-      for (const auto &entry : std::filesystem::directory_iterator(dir_path)) {
-        if (!entry.is_directory()) {
-          auto u8_file_name = entry.path().filename().u8string();
-          std::string file_name_str(u8_file_name.begin(), u8_file_name.end());
-          std::string full_href = href_of_head + file_name_str + href_of_tail +
-                                  file_name_str + "</a></br>";
-          res_str += full_href;
-        }
+      std::vector<std::string> files;
+      size_t static_dir_length = static_dir_.length();
+      get_static_dir_filenames(static_dir_, files, static_dir_length);
+      for (const auto &file : files) {
+        std::string full_href =
+            href_of_head + file + href_of_tail + file + "</a></br>";
+        res_str += full_href;
       }
       std::string ret =
           download_dir_response_head_ + res_str + download_dir_response_tail_;

--- a/lang/english/README.md
+++ b/lang/english/README.md
@@ -248,6 +248,22 @@ http://127.0.0.1:8080/purecpp/static/show.jpg
 //cinatra will send you the file, if the file is big file(more than 5M) the file will be downloaded by chunked. support continues download
 ```
 
+At the same time, you can use the `set_http_file_server(std::string path);` function to build an http file download server. The parameter path is the path of all downloadable files. Examples are as follows:
+
+```cpp
+#include "cinatra.hpp"
+using namespace cinatra;
+
+int main() {
+	http_server server(std::thread::hardware_concurrency());
+	server.set_http_file_server("http_file_server");
+	server.listen("0.0.0.0", "8080");
+	// ......
+}
+```
+
+In this time, when accessing the `http_file_server` path of the current server, all downloadable files will be displayed in the browser, and you can download them by clicking on them.
+
 ### Example 6: WebSocket
 
 ```cpp


### PR DESCRIPTION
cinatra server download optimize,Now user can use `set_http_file_server` function create http file server.
![image](https://github.com/qicosmos/cinatra/assets/20508859/68a49869-f7c7-4a24-b331-ec9781d3f853)
