### PR TITLE
Add explicit compile-time selection of Boost vs. Standalone ASIO

### DIFF
--- a/include/cinatra/client_factory.hpp
+++ b/include/cinatra/client_factory.hpp
@@ -32,8 +32,8 @@ private:
   client_factory(client_factory &&) = delete;
   client_factory &operator=(client_factory &&) = delete;
 
-  asio::io_service ios_;
-  asio::io_service::work work_;
+  asio_ns::io_service ios_;
+  asio_ns::io_service::work work_;
   std::shared_ptr<std::thread> thd_;
 };
 

--- a/include/cinatra/http_server.hpp
+++ b/include/cinatra/http_server.hpp
@@ -38,16 +38,16 @@ public:
   void set_ssl_conf(ssl_configure conf) { ssl_conf_ = std::move(conf); }
 
   bool port_in_use(unsigned short port) {
-    using namespace asio;
+    using namespace asio_ns;
     using ip::tcp;
 
     io_service svc;
     tcp::acceptor acept(svc);
 
-    std::error_code ec;
+    asio_error_code ec;
     acept.open(tcp::v4(), ec);
 #ifndef _WIN32
-    acept.set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
+    acept.set_option(asio_ns::ip::tcp::acceptor::reuse_address(true), ec);
 #endif
     acept.bind({tcp::v4(), port}, ec);
 
@@ -63,7 +63,7 @@ public:
       return false;
     }
 
-    asio::ip::tcp::resolver::query query(address.data(), port.data());
+    asio_ns::ip::tcp::resolver::query query(address.data(), port.data());
     auto [r, err_msg] = listen(query);
     return r;
   }
@@ -75,7 +75,7 @@ public:
       return false;
     }
 
-    asio::ip::tcp::resolver::query query(address.data(), port.data());
+    asio_ns::ip::tcp::resolver::query query(address.data(), port.data());
     auto [r, err_msg] = listen(query);
     error_msg = std::move(err_msg);
     return r;
@@ -87,27 +87,27 @@ public:
       return false;
     }
 
-    asio::ip::tcp::resolver::query query(port.data());
+    asio_ns::ip::tcp::resolver::query query(port.data());
     auto [r, err_msg] = listen(query);
     return r;
   }
 
   std::pair<bool, std::string>
-  listen(const asio::ip::tcp::resolver::query &query) {
-    asio::ip::tcp::resolver resolver(io_service_pool_.get_io_service());
-    asio::ip::tcp::resolver::iterator endpoints =
+  listen(const asio_ns::ip::tcp::resolver::query &query) {
+    asio_ns::ip::tcp::resolver resolver(io_service_pool_.get_io_service());
+    asio_ns::ip::tcp::resolver::iterator endpoints =
         resolver.resolve(query);
 
     bool r = false;
     std::string err_msg;
-    for (; endpoints != asio::ip::tcp::resolver::iterator();
+    for (; endpoints != asio_ns::ip::tcp::resolver::iterator();
          ++endpoints) {
-      asio::ip::tcp::endpoint endpoint = *endpoints;
+      asio_ns::ip::tcp::endpoint endpoint = *endpoints;
 
-      auto acceptor = std::make_shared<asio::ip::tcp::acceptor>(
+      auto acceptor = std::make_shared<asio_ns::ip::tcp::acceptor>(
           io_service_pool_.get_io_service());
       acceptor->open(endpoint.protocol());
-      acceptor->set_option(asio::ip::tcp::acceptor::reuse_address(true));
+      acceptor->set_option(asio_ns::ip::tcp::acceptor::reuse_address(true));
 
       try {
         acceptor->bind(endpoint);
@@ -247,7 +247,7 @@ public:
 
 private:
   void start_accept(
-      std::shared_ptr<asio::ip::tcp::acceptor> const &acceptor) {
+      std::shared_ptr<asio_ns::ip::tcp::acceptor> const &acceptor) {
     auto new_conn = std::make_shared<connection<ScoketType>>(
         io_service_pool_.get_io_service(), ssl_conf_, max_req_buf_size_,
         keep_alive_timeout_, http_handler_, upload_dir_,
@@ -262,7 +262,7 @@ private:
 
           if (!e) {
             new_conn->tcp_socket().set_option(
-                asio::ip::tcp::no_delay(true));
+                asio_ns::ip::tcp::no_delay(true));
             if (multipart_begin_) {
               new_conn->set_multipart_begin(multipart_begin_);
             }

--- a/include/cinatra/io_service_pool.hpp
+++ b/include/cinatra/io_service_pool.hpp
@@ -13,8 +13,8 @@ public:
       pool_size = 1; // set default value as 1
 
     for (std::size_t i = 0; i < pool_size; ++i) {
-      io_service_ptr io_service(new asio::io_service);
-      work_ptr work(new asio::io_service::work(*io_service));
+      io_service_ptr io_service(new asio_ns::io_service);
+      work_ptr work(new asio_ns::io_service::work(*io_service));
       io_services_.push_back(io_service);
       work_.push_back(work);
     }
@@ -44,8 +44,8 @@ public:
       io_services_[i]->stop();
   }
 
-  asio::io_service &get_io_service() {
-    asio::io_service &io_service = *io_services_[next_io_service_];
+  asio_ns::io_service &get_io_service() {
+    asio_ns::io_service &io_service = *io_services_[next_io_service_];
     ++next_io_service_;
     if (next_io_service_ == io_services_.size())
       next_io_service_ = 0;
@@ -53,8 +53,8 @@ public:
   }
 
 private:
-  using io_service_ptr = std::shared_ptr<asio::io_service>;
-  using work_ptr = std::shared_ptr<asio::io_service::work>;
+  using io_service_ptr = std::shared_ptr<asio_ns::io_service>;
+  using work_ptr = std::shared_ptr<asio_ns::io_service::work>;
 
   std::vector<io_service_ptr> io_services_;
   std::vector<work_ptr> work_;
@@ -64,8 +64,8 @@ private:
 class io_service_inplace : private noncopyable {
 public:
   explicit io_service_inplace() {
-    io_services_ = std::make_shared<asio::io_service>();
-    work_ = std::make_shared<asio::io_service::work>(*io_services_);
+    io_services_ = std::make_shared<asio_ns::io_service>();
+    work_ = std::make_shared<asio_ns::io_service::work>(*io_services_);
   }
 
   void run() { io_services_->run(); }
@@ -83,11 +83,11 @@ public:
       io_services_->stop();
   }
 
-  asio::io_service &get_io_service() { return *io_services_; }
+  asio_ns::io_service &get_io_service() { return *io_services_; }
 
 private:
-  using io_service_ptr = std::shared_ptr<asio::io_service>;
-  using work_ptr = std::shared_ptr<asio::io_service::work>;
+  using io_service_ptr = std::shared_ptr<asio_ns::io_service>;
+  using work_ptr = std::shared_ptr<asio_ns::io_service::work>;
 
   io_service_ptr io_services_;
   work_ptr work_;

--- a/include/cinatra/response.hpp
+++ b/include/cinatra/response.hpp
@@ -112,8 +112,8 @@ public:
     rep_str_.append(std::move(content_));
   }
 
-  std::vector<asio::const_buffer> to_buffers() {
-    std::vector<asio::const_buffer> buffers;
+  std::vector<asio_ns::const_buffer> to_buffers() {
+    std::vector<asio_ns::const_buffer> buffers;
     add_header("Host", "cinatra");
     if (session_ != nullptr && session_->is_need_update()) {
       auto cookie_str = session_->get_cookie().to_string();
@@ -123,25 +123,25 @@ public:
     buffers.reserve(headers_.size() * 4 + 5);
     buffers.emplace_back(to_buffer(status_));
     for (auto const &h : headers_) {
-      buffers.emplace_back(asio::buffer(h.first));
-      buffers.emplace_back(asio::buffer(name_value_separator));
-      buffers.emplace_back(asio::buffer(h.second));
-      buffers.emplace_back(asio::buffer(crlf));
+      buffers.emplace_back(asio_ns::buffer(h.first));
+      buffers.emplace_back(asio_ns::buffer(name_value_separator));
+      buffers.emplace_back(asio_ns::buffer(h.second));
+      buffers.emplace_back(asio_ns::buffer(crlf));
     }
 
-    buffers.push_back(asio::buffer(crlf));
+    buffers.push_back(asio_ns::buffer(crlf));
 
     if (body_type_ == content_type::string) {
       buffers.emplace_back(
-          asio::buffer(content_.data(), content_.size()));
+          asio_ns::buffer(content_.data(), content_.size()));
     }
 
     if (http_cache::get().need_cache(raw_url_)) {
       cache_data.clear();
       for (auto &buf : buffers) {
         cache_data.push_back(
-            std::string(asio::buffer_cast<const char *>(buf),
-                        asio::buffer_size(buf)));
+            std::string(asio_ns::buffer_cast<const char *>(buf),
+                        asio_ns::buffer_size(buf)));
       }
     }
 
@@ -241,25 +241,25 @@ public:
     add_header("Transfer-Encoding", "chunked");
   }
 
-  std::vector<asio::const_buffer>
+  std::vector<asio_ns::const_buffer>
   to_chunked_buffers(const char *chunk_data, size_t length, bool eof) {
-    std::vector<asio::const_buffer> buffers;
+    std::vector<asio_ns::const_buffer> buffers;
 
     if (length > 0) {
       // convert bytes transferred count to a hex string.
       chunk_size_ = to_hex_string(length);
 
       // Construct chunk based on rfc2616 section 3.6.1
-      buffers.push_back(asio::buffer(chunk_size_));
-      buffers.push_back(asio::buffer(crlf));
-      buffers.push_back(asio::buffer(chunk_data, length));
-      buffers.push_back(asio::buffer(crlf));
+      buffers.push_back(asio_ns::buffer(chunk_size_));
+      buffers.push_back(asio_ns::buffer(crlf));
+      buffers.push_back(asio_ns::buffer(chunk_data, length));
+      buffers.push_back(asio_ns::buffer(crlf));
     }
 
     // append last-chunk
     if (eof) {
-      buffers.push_back(asio::buffer(last_chunk));
-      buffers.push_back(asio::buffer(crlf));
+      buffers.push_back(asio_ns::buffer(last_chunk));
+      buffers.push_back(asio_ns::buffer(crlf));
     }
 
     return buffers;

--- a/include/cinatra/response_cv.hpp
+++ b/include/cinatra/response_cv.hpp
@@ -243,63 +243,63 @@ struct explode<0, digits...> : to_chars<digits...> {};
 template <unsigned num>
 struct num_to_string : detail::explode<num / 10, num % 10> {};
 
-inline asio::const_buffer to_buffer(status_type status) {
+inline asio_ns::const_buffer to_buffer(status_type status) {
   switch (status) {
   case status_type::switching_protocols:
-    return asio::buffer(switching_protocols.data(),
+    return asio_ns::buffer(switching_protocols.data(),
                                switching_protocols.length());
   case status_type::ok:
-    return asio::buffer(rep_ok.data(), rep_ok.length());
+    return asio_ns::buffer(rep_ok.data(), rep_ok.length());
   case status_type::created:
-    return asio::buffer(rep_created.data(), rep_created.length());
+    return asio_ns::buffer(rep_created.data(), rep_created.length());
   case status_type::accepted:
-    return asio::buffer(rep_accepted.data(), rep_created.length());
+    return asio_ns::buffer(rep_accepted.data(), rep_created.length());
   case status_type::no_content:
-    return asio::buffer(rep_no_content.data(), rep_no_content.length());
+    return asio_ns::buffer(rep_no_content.data(), rep_no_content.length());
   case status_type::partial_content:
-    return asio::buffer(rep_partial_content.data(),
+    return asio_ns::buffer(rep_partial_content.data(),
                                rep_partial_content.length());
   case status_type::multiple_choices:
-    return asio::buffer(rep_multiple_choices.data(),
+    return asio_ns::buffer(rep_multiple_choices.data(),
                                rep_multiple_choices.length());
   case status_type::moved_permanently:
-    return asio::buffer(rep_moved_permanently.data(),
+    return asio_ns::buffer(rep_moved_permanently.data(),
                                rep_moved_permanently.length());
   case status_type::temporary_redirect:
-    return asio::buffer(rep_temporary_redirect.data(),
+    return asio_ns::buffer(rep_temporary_redirect.data(),
                                rep_temporary_redirect.length());
   case status_type::moved_temporarily:
-    return asio::buffer(rep_moved_temporarily.data(),
+    return asio_ns::buffer(rep_moved_temporarily.data(),
                                rep_moved_temporarily.length());
   case status_type::not_modified:
-    return asio::buffer(rep_not_modified.data(),
+    return asio_ns::buffer(rep_not_modified.data(),
                                rep_not_modified.length());
   case status_type::bad_request:
-    return asio::buffer(rep_bad_request.data(),
+    return asio_ns::buffer(rep_bad_request.data(),
                                rep_bad_request.length());
   case status_type::unauthorized:
-    return asio::buffer(rep_unauthorized.data(),
+    return asio_ns::buffer(rep_unauthorized.data(),
                                rep_unauthorized.length());
   case status_type::forbidden:
-    return asio::buffer(rep_forbidden.data(), rep_forbidden.length());
+    return asio_ns::buffer(rep_forbidden.data(), rep_forbidden.length());
   case status_type::not_found:
-    return asio::buffer(rep_not_found.data(), rep_not_found.length());
+    return asio_ns::buffer(rep_not_found.data(), rep_not_found.length());
   case status_type::conflict:
-    return asio::buffer(rep_conflict.data(), rep_conflict.length());
+    return asio_ns::buffer(rep_conflict.data(), rep_conflict.length());
   case status_type::internal_server_error:
-    return asio::buffer(rep_internal_server_error.data(),
+    return asio_ns::buffer(rep_internal_server_error.data(),
                                rep_internal_server_error.length());
   case status_type::not_implemented:
-    return asio::buffer(rep_not_implemented.data(),
+    return asio_ns::buffer(rep_not_implemented.data(),
                                rep_not_implemented.length());
   case status_type::bad_gateway:
-    return asio::buffer(rep_bad_gateway.data(),
+    return asio_ns::buffer(rep_bad_gateway.data(),
                                rep_bad_gateway.length());
   case status_type::service_unavailable:
-    return asio::buffer(rep_service_unavailable.data(),
+    return asio_ns::buffer(rep_service_unavailable.data(),
                                rep_service_unavailable.length());
   default:
-    return asio::buffer(rep_internal_server_error.data(),
+    return asio_ns::buffer(rep_internal_server_error.data(),
                                rep_internal_server_error.length());
   }
 }

--- a/include/cinatra/smtp_client.hpp
+++ b/include/cinatra/smtp_client.hpp
@@ -20,7 +20,7 @@ struct email_data {
 template <typename T> class client {
 public:
   static constexpr bool IS_SSL = std::is_same_v<T, cinatra::SSL>;
-  client(asio::io_service &io_service)
+  client(asio_ns::io_service &io_service)
       : io_context_(io_service), socket_(io_service), resolver_(io_service) {}
 
   ~client() { close(); }
@@ -35,12 +35,12 @@ public:
       host.erase(0, pos + 3);
     }
 
-    asio::ip::tcp::resolver::query qry(
+    asio_ns::ip::tcp::resolver::query qry(
         host, server_.port,
-        asio::ip::resolver_query_base::numeric_service);
+        asio_ns::ip::resolver_query_base::numeric_service);
     std::error_code ec;
     auto endpoint_iterator = resolver_.resolve(qry, ec);
-    asio::connect(socket_, endpoint_iterator, ec);
+    asio_ns::connect(socket_, endpoint_iterator, ec);
     if (ec) {
       return;
     }
@@ -51,13 +51,13 @@ public:
 
     build_request();
 
-    asio::write(socket(), request_, ec);
+    asio_ns::write(socket(), request_, ec);
     if (ec) {
       return;
     }
 
     while (true) {
-      asio::read(socket(), response_, asio::transfer_at_least(1),
+      asio_ns::read(socket(), response_, asio_ns::transfer_at_least(1),
                         ec);
       if (ec) {
         return;
@@ -87,13 +87,13 @@ private:
   }
   void upgrade_to_ssl() {
 #ifdef CINATRA_ENABLE_SSL
-    asio::ssl::context ctx(asio::ssl::context::sslv23);
+    asio_ns::ssl::context ctx(asio_ns::ssl::context::sslv23);
     ctx.set_default_verify_paths();
     ctx.set_verify_mode(ctx.verify_fail_if_no_peer_cert);
 
     ssl_socket_ = std::make_unique<
-        asio::ssl::stream<asio::ip::tcp::socket &>>(socket_, ctx);
-    ssl_socket_->set_verify_mode(asio::ssl::verify_none);
+        asio_ns::ssl::stream<asio_ns::ip::tcp::socket &>>(socket_, ctx);
+    ssl_socket_->set_verify_mode(asio_ns::ssl::verify_none);
     ssl_socket_->set_verify_callback([](auto preverified, auto &ctx) {
       char subject_name[256];
       X509 *cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
@@ -103,7 +103,7 @@ private:
     });
 
     std::error_code ec;
-    ssl_socket_->handshake(asio::ssl::stream_base::client, ec);
+    ssl_socket_->handshake(asio_ns::ssl::stream_base::client, ec);
 #endif
   }
 
@@ -185,28 +185,28 @@ private:
 #endif
     }
 
-    socket_.shutdown(asio::ip::tcp::socket::shutdown_both, ignore_ec);
+    socket_.shutdown(asio_ns::ip::tcp::socket::shutdown_both, ignore_ec);
     socket_.close(ignore_ec);
   }
 
 private:
-  asio::io_context &io_context_;
-  asio::ip::tcp::socket socket_;
+  asio_ns::io_context &io_context_;
+  asio_ns::ip::tcp::socket socket_;
 #ifdef CINATRA_ENABLE_SSL
-  std::unique_ptr<asio::ssl::stream<asio::ip::tcp::socket &>>
+  std::unique_ptr<asio_ns::ssl::stream<asio_ns::ip::tcp::socket &>>
       ssl_socket_;
 #endif
-  asio::ip::tcp::resolver resolver_;
+  asio_ns::ip::tcp::resolver resolver_;
 
   email_server server_;
   email_data data_;
 
-  asio::streambuf request_;
-  asio::streambuf response_;
+  asio_ns::streambuf request_;
+  asio_ns::streambuf response_;
 };
 
 template <typename T>
-static inline auto get_smtp_client(asio::io_service &io_service) {
+static inline auto get_smtp_client(asio_ns::io_service &io_service) {
   return smtp::client<T>(io_service);
 }
 

--- a/include/cinatra/use_asio.hpp
+++ b/include/cinatra/use_asio.hpp
@@ -1,17 +1,49 @@
 #pragma once
 
-#if defined(ASIO_STANDALONE)
-// MSVC : define environment path 'ASIO_STANDALONE_INCLUDE', e.g.
-// 'E:\bdlibs\asio-1.10.6\include'
+#ifdef CINATRA_ENABLE_BOOST_ASIO
+
+#include <boost/asio.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/steady_timer.hpp>
+
+#if defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)
+#include <boost/asio/ssl.hpp>
+#endif // defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)
+
+#if defined(ENABLE_FILE_IO_URING)
+#include <boost/asio/random_access_file.hpp>
+#include <boost/asio/stream_file.hpp>
+#endif
+
+namespace asio_ns = boost::asio;
+
+using asio_error_code = boost::system::error_code;
+
+#elif defined(ASIO_STANDALONE) || defined(CINATRA_ENABLE_LOCAL_ASIO)
+
+#define ASIO_STANDALONE
 
 #include <asio.hpp>
-#ifdef CINATRA_ENABLE_SSL
-#include <asio/ssl.hpp>
-#endif
+#include <asio/error_code.hpp>
 #include <asio/steady_timer.hpp>
 
-using tcp_socket = asio::ip::tcp::socket;
-#ifdef CINATRA_ENABLE_SSL
-using ssl_socket = asio::ssl::stream<asio::ip::tcp::socket>;
+#if defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)
+#include <asio/ssl.hpp>
+#endif // defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)
+
+#if defined(ENABLE_FILE_IO_URING)
+#include <asio/random_access_file.hpp>
+#include <asio/stream_file.hpp>
 #endif
-#endif
+
+namespace asio_ns = asio;
+
+using asio_error_code = asio_ns::error_code;
+
+#endif // CINATRA_ENABLE_BOOST_ASIO
+
+using tcp_socket = asio_ns::ip::tcp::socket;
+
+#if defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)
+using ssl_socket = asio_ns::ssl::stream<asio_ns::ip::tcp::socket>;
+#endif // defined(ENABLE_SSL) || defined(CINATRA_ENABLE_SSL)

--- a/include/cinatra/websocket.hpp
+++ b/include/cinatra/websocket.hpp
@@ -163,11 +163,11 @@ public:
     return {msg_header_, header_length};
   }
 
-  std::vector<asio::const_buffer>
+  std::vector<asio_ns::const_buffer>
   format_message(const char *src, size_t length, opcode code) {
     size_t header_length = encode_header(length, code);
-    return {asio::buffer(msg_header_, header_length),
-            asio::buffer(src, length)};
+    return {asio_ns::buffer(msg_header_, header_length),
+            asio_ns::buffer(src, length)};
   }
 
   close_frame parse_close_payload(char *src, size_t length) {


### PR DESCRIPTION
Abstract asio namespace and use compile options to select whether it is Boost ASIO or Standalone ASIO that is being used.

Ensure that common async types such as cinatra::ssl_socket continue to be correctly mapped.