### PR TITLE
get/set http headers

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -280,11 +280,14 @@ class coro_http_client {
 
   bool has_closed() { return socket_->has_closed_; }
 
+  const auto &get_headers() { return req_headers_; }
+
+  void set_headers(std::unordered_map<std::string, std::string> req_headers) {
+    req_headers_ = std::move(req_headers);
+  }
+
   bool add_header(std::string key, std::string val) {
     if (key.empty())
-      return false;
-
-    if (key == "Host")
       return false;
 
     req_headers_[key] = std::move(val);
@@ -1074,7 +1077,12 @@ class coro_http_client {
       req_str.append(" HTTP/1.1\r\n");
     }
     else {
-      req_str.append(" HTTP/1.1\r\nHost:").append(u.host).append("\r\n");
+      if (req_headers_.find("Host") == req_headers_.end()) {
+        req_str.append(" HTTP/1.1\r\nHost:").append(u.host).append("\r\n");
+      }
+      else {
+        req_str.append(" HTTP/1.1\r\n");
+      }
     }
 
     auto type_str = get_content_type_str(ctx.content_type);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -450,7 +450,6 @@ TEST_CASE("test bad uri") {
   CHECK(client.add_header("hello", "cinatra"));
   CHECK(client.add_header("hello", "cinatra"));
   CHECK(!client.add_header("", "cinatra"));
-  CHECK(!client.add_header("Host", "cinatra"));
   client.add_str_part("hello", "world");
   auto result = async_simple::coro::syncAwait(
       client.async_upload_multipart("http://www.badurlrandom.org"));


### PR DESCRIPTION
```c++
std::unordered_map<std::string, std::string> headers;
headers.emplace("Host", "cinatra");
headers.emplace("User-Agent", "ylt");

client.set_headers(std::move(headers));

// http delete request
auto lazy = client.async_delete(uri, "", cinatra::req_content_type::none);
auto result = async_simple::coro::syncAwait(lazy);
```