### PR TITLE
fix: server stop send websocket close message

### DIFF
--- a/include/cinatra/connection.hpp
+++ b/include/cinatra/connection.hpp
@@ -686,6 +686,15 @@ class connection : public base_connection,
       return;
     }
 
+    if (req_.get_content_type() == content_type::websocket) {
+      req_.set_websocket_state(true);
+      std::string close_reason = "server close\n";
+      std::string close_msg = ws_.format_close_payload(
+          close_code::normal, close_reason.data(), close_reason.size());
+      auto header = ws_.format_header(close_msg.length(), opcode::close);
+      send_msg(std::move(header), std::move(close_msg));
+    }
+
     req_.close_upload_file();
     shutdown();
     std::error_code ec;
@@ -1133,7 +1142,9 @@ class connection : public base_connection,
         [this, self](const std::error_code &ec, size_t bytes_transferred) {
           if (ec) {
             cancel_timer();
-            req_.call_event(data_proc_state::data_error);
+
+            if (!req_.get_websocket_state())
+              req_.call_event(data_proc_state::data_error);
 
             close();
             return;
@@ -1239,6 +1250,7 @@ class connection : public base_connection,
             close_code::normal, close_frame.message, len);
         auto header = ws_.format_header(close_msg.length(), opcode::close);
         send_msg(std::move(header), std::move(close_msg));
+        req_.set_websocket_state(true);
       } break;
       case cinatra::ws_frame_type::WS_PING_FRAME: {
         auto header = ws_.format_header(payload.length(), opcode::pong);

--- a/include/cinatra/request.hpp
+++ b/include/cinatra/request.hpp
@@ -588,6 +588,10 @@ class request {
 
   data_proc_state get_state() const { return state_; }
 
+  void set_websocket_state(bool is_closed) { is_websocket_closed_ = is_closed; }
+
+  bool get_websocket_state() { return is_websocket_closed_; }
+
   void set_part_data(std::string_view data) {
 #ifdef CINATRA_ENABLE_GZIP
     if (has_gzip_) {
@@ -944,5 +948,7 @@ class request {
       event_call_backs_ = {};
   std::smatch matches_;
   std::unordered_map<std::string, int> restful_params_;
+
+  bool is_websocket_closed_ = false;
 };
 }  // namespace cinatra


### PR DESCRIPTION
for [issue 441](https://github.com/qicosmos/cinatra/issues/411)

While server stop websocket send close frame to connected client. 

Before modification:
The client enters the error handling process.
![图片](https://github.com/qicosmos/cinatra/assets/20508859/c3e6e8fd-14df-4d09-ae24-c84a7312e889)
After modification:
The client enters the close handling process.
![图片](https://github.com/qicosmos/cinatra/assets/20508859/a3195dbd-68c3-4c5e-b4da-75b7f04338b3)



