### PR TITLE
fix: client send ping server need reset timer

### DIFF
--- a/include/cinatra/connection.hpp
+++ b/include/cinatra/connection.hpp
@@ -1258,6 +1258,7 @@ class connection : public base_connection,
         req_.set_websocket_state(true);
       } break;
       case cinatra::ws_frame_type::WS_PING_FRAME: {
+        reset_timer();
         auto header = ws_.format_header(payload.length(), opcode::pong);
         send_msg(std::move(header), std::move(payload));
       } break;


### PR DESCRIPTION
[pr](https://github.com/qicosmos/cinatra/issues/411)
client send ping and it's connection still disconnect.

because websocket server don't reset timer when recive client ping.Now fix it.