### PR TITLE
add callback for chunked upload

### DIFF
--- a/include/cinatra/ylt/coro_io/coro_file_op.hpp
+++ b/include/cinatra/ylt/coro_io/coro_file_op.hpp
@@ -9,7 +9,7 @@
 
 namespace coro_file_io {
 struct file_result {
-  int err_code = 0;
+  int err = 0;
   bool eof = false;
   size_t size = 0;
 };
@@ -51,7 +51,7 @@ inline async_simple::coro::Lazy<file_result> async_op(auto io_func,
 
   auto len_val = co_await coro_io::post(std::move(func), executor);
   result.size = len_val.value();
-  result.err_code = ferror(stream);
+  result.err = ferror(stream);
   if (is_read) {
     result.eof = feof(stream);
   }
@@ -77,7 +77,7 @@ inline async_simple::coro::Lazy<file_result> async_op_at(auto io_func,
   file_result result{};
   int ret = std::fseek(stream, offset, SEEK_CUR);
   if (ret != 0) {
-    result.err_code = ret;
+    result.err = ret;
     co_return result;
   }
 
@@ -157,7 +157,7 @@ inline async_simple::coro::Lazy<file_result> async_prw(auto io_func,
     result.size = len;
   }
   else {
-    result.err_code = len;
+    result.err = len;
   }
 
   co_return result;

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -334,7 +334,7 @@ TEST_CASE("delay reply, server stop, form-urlencode, qureies, throw") {
 }
 
 bool create_file(std::string_view filename, size_t file_size = 1024) {
-  std::ofstream out(filename, std::ios::binary);
+  std::ofstream out(filename.data(), std::ios::binary);
   if (!out.is_open()) {
     return false;
   }

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -22,6 +22,7 @@
 
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_server.hpp"
+#include "cinatra/ylt/coro_io/coro_file_op.hpp"
 #include "doctest/doctest.h"
 
 using namespace cinatra;
@@ -332,6 +333,44 @@ TEST_CASE("delay reply, server stop, form-urlencode, qureies, throw") {
   std::cout << "ok\n";
 }
 
+bool create_file(std::string_view filename, size_t file_size = 1024) {
+  std::ofstream out(filename, std::ios::binary);
+  if (!out.is_open()) {
+    return false;
+  }
+
+  std::string str(file_size, 'A');
+  out.write(str.data(), str.size());
+  return true;
+}
+
+struct read_result {
+  std::string_view buf;
+  bool eof;
+  int err;
+};
+
+async_simple::coro::Lazy<resp_data> chunked_upload1(coro_http_client &client) {
+  std::string filename = "test.txt";
+  create_file(filename, 1010);
+
+  auto fptr = coro_file_io::fopen_shared(filename, "rb");
+  std::string buf;
+  detail::resize(buf, 100);
+
+  auto fn = [file = fptr.get(),
+             &buf]() -> async_simple::coro::Lazy<read_result> {
+    coro_file_io::file_result result =
+        co_await coro_file_io::async_read(file, buf.data(), buf.size());
+    co_return read_result{std::string_view(buf.data(), result.size), result.eof,
+                          result.err};
+  };
+
+  auto result = co_await client.async_upload_chunked(
+      "http://127.0.0.1:9001/chunked"sv, http_method::POST, std::move(fn));
+  co_return result;
+}
+
 TEST_CASE("chunked request") {
   cinatra::coro_http_server server(1, 9001);
   server.set_http_handler<cinatra::GET, cinatra::POST>(
@@ -354,6 +393,7 @@ TEST_CASE("chunked request") {
           content.append(result.data);
         }
 
+        std::cout << "content size: " << content.size() << "\n";
         std::cout << content << "\n";
         resp.set_format_type(format_type::chunked);
         resp.set_status_and_content(status_type::ok, "chunked ok");
@@ -384,6 +424,10 @@ TEST_CASE("chunked request") {
   std::this_thread::sleep_for(200ms);
 
   coro_http_client client{};
+  auto r = async_simple::coro::syncAwait(chunked_upload1(client));
+  CHECK(r.status == 200);
+  CHECK(r.resp_body == "chunked ok");
+
   auto ss = std::make_shared<std::stringstream>();
   *ss << "hello world";
   auto result = async_simple::coro::syncAwait(client.async_upload_chunked(

--- a/tests/test_corofile.cpp
+++ b/tests/test_corofile.cpp
@@ -81,18 +81,18 @@ TEST_CASE("coro_file_op basic test") {
         async_simple::coro::syncAwait(coro_file_io::async_read(fptr, buf, 100));
     CHECK(result.eof == false);
     CHECK(result.size == 100);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     result =
         async_simple::coro::syncAwait(coro_file_io::async_read(fptr, buf, 100));
     CHECK(result.eof == true);
     CHECK(result.size == 90);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
 
     result =
         async_simple::coro::syncAwait(coro_file_io::async_read(fptr, buf, 100));
     CHECK(result.eof == true);
     CHECK(result.size == 0);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     coro_file_io::fclose(fptr);
   }
 
@@ -103,7 +103,7 @@ TEST_CASE("coro_file_op basic test") {
         coro_file_io::async_read(file_ptr.get(), buf, 100));
     CHECK(result.eof == false);
     CHECK(result.size == 100);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     file_ptr.reset();
     CHECK(file_ptr == nullptr);
   }
@@ -116,7 +116,7 @@ TEST_CASE("coro_file_op basic test") {
         coro_file_io::async_read_at(fptr, 100, buf, 100));
     CHECK(result.eof == true);
     CHECK(result.size == 90);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     coro_file_io::fclose(fptr);
   }
 
@@ -127,7 +127,7 @@ TEST_CASE("coro_file_op basic test") {
     auto result = async_simple::coro::syncAwait(
         coro_file_io::async_write(fptr, buf.data(), buf.size()));
     CHECK(result.size == 10);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     coro_file_io::fclose(fptr);
   }
   {
@@ -145,7 +145,7 @@ TEST_CASE("coro_file_op basic test") {
     auto result = async_simple::coro::syncAwait(
         coro_file_io::async_write_at(fptr, 10, buf.data(), buf.size()));
     CHECK(result.size == 10);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
 
     coro_file_io::fclose(fptr);
   }
@@ -187,13 +187,13 @@ TEST_CASE("coro_file_op basic test") {
         coro_file_io::async_pread(fd, 0, buf1, 200));
     CHECK(result.eof == false);
     CHECK(result.size == 190);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
 
     result = async_simple::coro::syncAwait(
         coro_file_io::async_pread(fd, 190, buf1, 200));
     CHECK(result.eof == true);
     CHECK(result.size == 0);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
 
     close(fd);
   }
@@ -203,13 +203,13 @@ TEST_CASE("coro_file_op basic test") {
     auto result = async_simple::coro::syncAwait(
         coro_file_io::async_pwrite(fd, 0, buf.data(), buf.size()));
     CHECK(result.size == 10);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
 
     std::string buf1 = "dddddddddd";
     result = async_simple::coro::syncAwait(
         coro_file_io::async_pwrite(fd, 10, buf1.data(), buf1.size()));
     CHECK(result.size == 10);
-    CHECK(result.err_code == 0);
+    CHECK(result.err == 0);
     close(fd);
   }
   {


### PR DESCRIPTION
user can provide file reading callback when upload chunked.

```c++
async_simple::coro::Lazy<resp_data> chunked_upload1(coro_http_client &client) {
  std::string filename = "test.txt";
  create_file(filename, 1010);

  auto fptr = coro_file_io::fopen_shared(filename, "rb");
  std::string buf;
  detail::resize(buf, 100);

  auto fn = [file = fptr.get(),
             &buf]() -> async_simple::coro::Lazy<read_result> {
    coro_file_io::file_result result =
        co_await coro_file_io::async_read(file, buf.data(), buf.size());
    co_return read_result{std::string_view(buf.data(), result.size), result.eof,
                          result.err};
  };

  auto result = co_await client.async_upload_chunked(
      "http://127.0.0.1:9001/chunked"sv, http_method::POST, std::move(fn));
  co_return result;
}
```