### PR TITLE
simplify ssl request

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -991,10 +991,13 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         bool no_schema = !has_schema(uri);
 
         if (no_schema) {
+#ifdef CINATRA_ENABLE_SSL
           if (is_ssl_schema_) {
             append_uri.append("https://").append(uri);
           }
-          else {
+          else
+#endif
+          {
             append_uri.append("http://").append(uri);
           }
         }
@@ -1025,6 +1028,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         }
 
         if (u.is_ssl) {
+#ifdef CINATRA_ENABLE_SSL
           if (!has_init_ssl_) {
             size_t pos = u.host.find("www.");
             std::string host;
@@ -1040,6 +1044,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
               co_return data;
             }
           }
+#endif
           if (ec = co_await handle_shake(); ec) {
             break;
           }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ add_test(NAME test_time_util COMMAND test_time_util)
 add_executable(test_coro_http_server test_coro_http_server.cpp)
 add_test(NAME test_coro_http_server COMMAND test_coro_http_server)
 
-option(CINATRA_ENABLE_SSL "Enable ssl support" OFF)
+option(CINATRA_ENABLE_SSL "Enable ssl support" ON)
 if (CINATRA_ENABLE_SSL)
     message(STATUS "Use SSL")
     find_package(OpenSSL REQUIRED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,7 +61,7 @@ add_test(NAME test_time_util COMMAND test_time_util)
 add_executable(test_coro_http_server test_coro_http_server.cpp)
 add_test(NAME test_coro_http_server COMMAND test_coro_http_server)
 
-option(CINATRA_ENABLE_SSL "Enable ssl support" ON)
+option(CINATRA_ENABLE_SSL "Enable ssl support" OFF)
 if (CINATRA_ENABLE_SSL)
     message(STATUS "Use SSL")
     find_package(OpenSSL REQUIRED)

--- a/tests/test_cinatra_websocket.cpp
+++ b/tests/test_cinatra_websocket.cpp
@@ -35,8 +35,8 @@ TEST_CASE("test wss client") {
   f.wait();
 
   auto client = std::make_shared<coro_http_client>();
-  bool ok =
-      client->init_ssl("localhost", "../../include/cinatra", "server.crt");
+  bool ok = client->init_ssl(asio::ssl::verify_peer,
+                             "../../include/cinatra/server.crt");
   REQUIRE_MESSAGE(ok == true, "init ssl fail, please check ssl config");
 
   std::promise<void> promise;

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <vector>
 
+#include "asio/ssl/verify_mode.hpp"
 #include "async_simple/coro/Lazy.h"
 #include "async_simple/coro/SyncAwait.h"
 #include "cinatra/coro_http_connection.hpp"
@@ -908,7 +909,8 @@ TEST_CASE("test ssl server") {
   std::this_thread::sleep_for(200ms);
 
   coro_http_client client{};
-  [[maybe_unused]] auto r = client.init_ssl();
+  [[maybe_unused]] auto r = client.init_ssl(asio::ssl::verify_peer,
+                                            "../../include/cinatra/server.crt");
 
   auto result = client.get("https://127.0.0.1:9001/ssl");
   CHECK(result.status == 200);

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -9,7 +9,6 @@
 #include <thread>
 #include <vector>
 
-#include "asio/ssl/verify_mode.hpp"
 #include "async_simple/coro/Lazy.h"
 #include "async_simple/coro/SyncAwait.h"
 #include "cinatra/coro_http_connection.hpp"


### PR DESCRIPTION
simplify ssl request, client.init_ssl() is optional.

```c++
#ifdef CINATRA_ENABLE_SSL
  {
    coro_http_client client{};
    auto result = client.get("https://www.bing.com");
    CHECK(result.status == 200);
  }
#endif
```