### PR TITLE
static file server can use aspects

### DIFF
--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -196,8 +196,9 @@ class coro_http_server {
 
   void set_transfer_chunked_size(size_t size) { chunked_size_ = size; }
 
-  void set_static_res_dir(std::string_view uri_suffix = "",
-                          std::string file_path = "www") {
+  void set_static_res_dir(
+      std::string_view uri_suffix = "", std::string file_path = "www",
+      std::vector<std::shared_ptr<base_aspect>> aspects = {}) {
     bool has_double_dot = (file_path.find("..") != std::string::npos) ||
                           (uri_suffix.find("..") != std::string::npos);
     if (std::filesystem::path(file_path).has_root_path() ||
@@ -415,7 +416,8 @@ class coro_http_server {
                 }
               }
             }
-          });
+          },
+          aspects);
     }
   }
 

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -408,6 +408,10 @@ struct check_t : public base_aspect {
 
 TEST_CASE("test aspects") {
   coro_http_server server(1, 9001);
+  create_file("test_aspect.txt", 64);
+  std::vector<std::shared_ptr<base_aspect>> aspects = {
+      std::make_shared<log_t>(), std::make_shared<check_t>()};
+  server.set_static_res_dir("", "", aspects);
   server.set_http_handler<GET, POST>(
       "/",
       [](coro_http_request &req, coro_http_response &resp) {
@@ -445,6 +449,9 @@ TEST_CASE("test aspects") {
 
   result = client.get("http://127.0.0.1:9001/coro");
   check(result);
+
+  result = client.get("http://127.0.0.1:9001/test_aspect.txt");
+  CHECK(result.status == 200);
 }
 
 TEST_CASE("use out context") {


### PR DESCRIPTION
```c++
  coro_http_server server(1, 9001);
  std::vector<std::shared_ptr<base_aspect>> aspects = {
      std::make_shared<log_t>(), std::make_shared<check_t>()};
  server.set_static_res_dir("", "", aspects);
  server.sync_start();
```