### PR TITLE
type alias

### DIFF
--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -713,4 +713,8 @@ class coro_http_server {
   coro_http_router router_;
   bool need_shrink_every_time_ = false;
 };
+
+using http_server = coro_http_server;
+using request = coro_http_request;
+using response = coro_http_response;
 }  // namespace cinatra

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -460,6 +460,19 @@ TEST_CASE("get post") {
   server.stop();
 }
 
+TEST_CASE("test alias") {
+  http_server server(1, 9001);
+  server.set_http_handler<GET>("/", [](request &req, response &resp) {
+    resp.set_status_and_content(status_type::ok, "ok");
+  });
+  server.async_start();
+  std::this_thread::sleep_for(300ms);
+
+  coro_http_client client{};
+  auto result = client.get("http://127.0.0.1:9001/");
+  CHECK(result.resp_body == "ok");
+}
+
 struct log_t : public base_aspect {
   bool before(coro_http_request &, coro_http_response &) {
     std::cout << "before log" << std::endl;


### PR DESCRIPTION
also can use old type name.
```c++
  http_server server(1, 9001);
  server.set_http_handler<GET>("/", [](request &req, response &resp) {
    resp.set_status_and_content(status_type::ok, "ok");
  });
  server.sync_start();
```
