### PR TITLE
redirect

### DIFF
--- a/include/cinatra/coro_http_response.hpp
+++ b/include/cinatra/coro_http_response.hpp
@@ -271,6 +271,13 @@ class coro_http_response {
     cookies_[cookie.get_name()] = cookie;
   }
 
+  void redirect(const std::string &url, bool is_forever = false) {
+    add_header("Location", url);
+    is_forever == false
+        ? set_status_and_content(status_type::moved_temporarily)
+        : set_status_and_content(status_type::moved_permanently);
+  }
+
  private:
   status_type status_;
   format_type fmt_type_;


### PR DESCRIPTION
add redirect for response.

```c++
  coro_http_server server(1, 9001);
  server.set_http_handler<GET>(
      "/", [](coro_http_request &req, coro_http_response &resp) {
        resp.redirect("/test");
      });

  server.set_http_handler<GET>(
      "/test", [](coro_http_request &req, coro_http_response &resp) {
        resp.set_status_and_content(status_type::ok, "redirect ok");
      });

  server.sync_start();
```