### PR TITLE
feat: add websocket permessage-deflate

### DIFF
--- a/include/cinatra/coro_http_connection.hpp
+++ b/include/cinatra/coro_http_connection.hpp
@@ -21,6 +21,9 @@
 #include "sha1.hpp"
 #include "string_resize.hpp"
 #include "websocket.hpp"
+#ifdef CINATRA_ENABLE_GZIP
+#include "gzip.hpp"
+#endif
 #include "ylt/coro_io/coro_file.hpp"
 #include "ylt/coro_io/coro_io.hpp"
 
@@ -132,6 +135,14 @@ class coro_http_connection
         if (body_len == 0) {
           if (parser_.method() == "GET"sv) {
             if (request_.is_upgrade()) {
+#ifdef CINATRA_ENABLE_GZIP
+              if (request_.is_support_compressed()) {
+                is_client_ws_compressed_ = true;
+              }
+              else {
+                is_client_ws_compressed_ = false;
+              }
+#endif
               // websocket
               build_ws_handshake_head();
               bool ok = co_await reply(true);  // response ws handshake
@@ -551,6 +562,32 @@ class coro_http_connection
 
   async_simple::coro::Lazy<std::error_code> write_websocket(
       std::string_view msg, opcode op = opcode::text) {
+#ifdef CINATRA_ENABLE_GZIP
+    std::string dest_buf;
+    if (is_client_ws_compressed_ && msg.size() > 0) {
+      if (!cinatra::gzip_codec::deflate(std::string(msg), dest_buf)) {
+        CINATRA_LOG_ERROR << "compuress data error, data: " << msg;
+        co_return std::make_error_code(std::errc::protocol_error);
+      }
+
+      auto header = ws_.format_header(dest_buf.length(), op, true);
+      std::vector<asio::const_buffer> buffers;
+      buffers.push_back(asio::buffer(header));
+      buffers.push_back(asio::buffer(dest_buf));
+
+      auto [ec, sz] = co_await async_write(buffers);
+      co_return ec;
+    }
+    else {
+      auto header = ws_.format_header(msg.length(), op);
+      std::vector<asio::const_buffer> buffers;
+      buffers.push_back(asio::buffer(header));
+      buffers.push_back(asio::buffer(msg));
+
+      auto [ec, sz] = co_await async_write(buffers);
+      co_return ec;
+    }
+#else
     auto header = ws_.format_header(msg.length(), op);
     std::vector<asio::const_buffer> buffers;
     buffers.push_back(asio::buffer(header));
@@ -558,6 +595,7 @@ class coro_http_connection
 
     auto [ec, sz] = co_await async_write(buffers);
     co_return ec;
+#endif
   }
 
   async_simple::coro::Lazy<websocket_result> read_websocket() {
@@ -612,8 +650,26 @@ class coro_http_connection
             break;
           case cinatra::ws_frame_type::WS_TEXT_FRAME:
           case cinatra::ws_frame_type::WS_BINARY_FRAME: {
+#ifdef CINATRA_ENABLE_GZIP
+            std::string out;
+            if (is_client_ws_compressed_) {
+              if (!cinatra::gzip_codec::inflate(
+                      std::string(payload.begin(), payload.end()), out)) {
+                CINATRA_LOG_ERROR << "uncompuress data error";
+                result.ec = std::make_error_code(std::errc::protocol_error);
+                break;
+              }
+              result.eof = true;
+              result.data = {out.data(), out.size()};
+            }
+            else {
+              result.eof = true;
+              result.data = {payload.data(), payload.size()};
+            }
+#else
             result.eof = true;
             result.data = {payload.data(), payload.size()};
+#endif
           } break;
           case cinatra::ws_frame_type::WS_CLOSE_FRAME: {
             close_frame close_frame =
@@ -803,6 +859,12 @@ class coro_http_connection
     if (!protocal_str.empty()) {
       response_.add_header("Sec-WebSocket-Protocol", std::string(protocal_str));
     }
+#ifdef CINATRA_ENABLE_GZIP
+    if (is_client_ws_compressed_) {
+      response_.add_header("Sec-WebSocket-Extensions",
+                           "permessage-deflate; client_no_context_takeover");
+    }
+#endif
   }
 
  private:
@@ -825,6 +887,9 @@ class coro_http_connection
   std::atomic<std::chrono::system_clock::time_point> last_rwtime_;
   uint64_t max_part_size_ = 8 * 1024 * 1024;
   std::string resp_str_;
+#ifdef CINATRA_ENABLE_GZIP
+  bool is_client_ws_compressed_ = false;
+#endif
 
   websocket ws_;
 #ifdef CINATRA_ENABLE_SSL

--- a/include/cinatra/coro_http_request.hpp
+++ b/include/cinatra/coro_http_request.hpp
@@ -208,6 +208,14 @@ class coro_http_request {
     return true;
   }
 
+  bool is_support_compressed() {
+    auto extension_str = get_header_value("Sec-WebSocket-Extensions");
+    if (extension_str.find("permessage-deflate") != std::string::npos) {
+      return true;
+    }
+    return false;
+  }
+
   void set_aspect_data(std::string data) {
     aspect_data_.push_back(std::move(data));
   }

--- a/include/cinatra/gzip.hpp
+++ b/include/cinatra/gzip.hpp
@@ -140,4 +140,163 @@ inline int uncompress_file(const char *src_file, const char *out_file_name) {
 
   return 0;
 }
+
+bool inflate(const std::string &str_src, std::string &str_dest) {
+  int err = Z_DATA_ERROR;
+  // Create stream
+  z_stream zs = {0};
+  // Set output data streams, do this here to avoid overwriting on recursive
+  // calls
+  const int OUTPUT_BUF_SIZE = 8192;
+  Bytef bytes_out[OUTPUT_BUF_SIZE] = {0};
+
+  // Initialise the z_stream
+  err = ::inflateInit2(&zs, -15);
+  if (err != Z_OK) {
+    return false;
+  }
+
+  // Use whatever input is provided
+  zs.next_in = (Bytef *)(str_src.c_str());
+  zs.avail_in = str_src.length();
+
+  do {
+    try {
+      // Initialise stream values
+      // zs->zalloc = (alloc_func)0;
+      // zs->zfree = (free_func)0;
+      // zs->opaque = (voidpf)0;
+
+      zs.next_out = bytes_out;
+      zs.avail_out = OUTPUT_BUF_SIZE;
+
+      // Try to unzip the data
+      err = ::inflate(&zs, Z_SYNC_FLUSH);
+
+      // Is zip finished reading all currently available input and writing all
+      // generated output
+      if (err == Z_STREAM_END) {
+        // Finish up
+        int kerr = ::inflateEnd(&zs);
+
+        // Got a good result, set the size to the amount unzipped in this call
+        // (including all recursive calls)
+
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+        return true;
+      }
+      else if ((err == Z_OK) && (zs.avail_out == 0) && (zs.avail_in != 0)) {
+        // Output array was not big enough, call recursively until there is
+        // enough space
+
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+
+        continue;
+      }
+      else if ((err == Z_OK) && (zs.avail_in == 0)) {
+        // All available input has been processed, everything ok.
+        // Set the size to the amount unzipped in this call (including all
+        // recursive calls)
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+
+        int kerr = ::inflateEnd(&zs);
+
+        break;
+      }
+      else {
+        return false;
+      }
+    } catch (...) {
+      return false;
+    }
+  } while (true);
+
+  return err == Z_OK;
+}
+
+bool deflate(const std::string &str_src, std::string &str_dest) {
+  int err = Z_DATA_ERROR;
+  // Create stream
+  z_stream zs = {0};
+  // Set output data streams, do this here to avoid overwriting on recursive
+  // calls
+  const int OUTPUT_BUF_SIZE = 8192;
+  Bytef bytes_out[OUTPUT_BUF_SIZE] = {0};
+
+  // Initialise the z_stream
+  err = ::deflateInit2(&zs, 1, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+  if (err != Z_OK) {
+    return false;
+  }
+  // Use whatever input is provided
+  zs.next_in = (Bytef *)(str_src.c_str());
+  zs.avail_in = str_src.length();
+
+  do {
+    try {
+      // Initialise stream values
+      // zs->zalloc = (alloc_func)0;
+      // zs->zfree = (free_func)0;
+      // zs->opaque = (voidpf)0;
+
+      zs.next_out = bytes_out;
+      zs.avail_out = OUTPUT_BUF_SIZE;
+
+      // Try to unzip the data
+      err = ::deflate(&zs, Z_SYNC_FLUSH);
+
+      // Is zip finished reading all currently available input and writing all
+      // generated output
+      if (err == Z_STREAM_END) {
+        // Finish up
+        int kerr = ::deflateEnd(&zs);
+
+        // Got a good result, set the size to the amount unzipped in this call
+        // (including all recursive calls)
+
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+        return true;
+      }
+      else if ((err == Z_OK) && (zs.avail_out == 0) && (zs.avail_in != 0)) {
+        // Output array was not big enough, call recursively until there is
+        // enough space
+
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+
+        continue;
+      }
+      else if ((err == Z_OK) && (zs.avail_in == 0)) {
+        // All available input has been processed, everything ok.
+        // Set the size to the amount unzipped in this call (including all
+        // recursive calls)
+        str_dest.append((const char *)bytes_out,
+                        OUTPUT_BUF_SIZE - zs.avail_out);
+
+        int kerr = ::deflateEnd(&zs);
+
+        break;
+      }
+      else {
+        return false;
+      }
+    } catch (...) {
+      return false;
+    }
+  } while (true);
+
+  if (err == Z_OK) {
+    // subtract 4 to remove the extra 00 00 ff ff added to the end of the deflat
+    // function
+    str_dest = str_dest.substr(0, str_dest.length() - 4);
+    return true;
+  }
+
+  return false;
+}
+
 }  // namespace cinatra::gzip_codec

--- a/include/cinatra/websocket.hpp
+++ b/include/cinatra/websocket.hpp
@@ -121,19 +121,23 @@ class websocket {
     return ws_frame_type::WS_BINARY_FRAME;
   }
 
-  std::string format_header(size_t length, opcode code) {
-    size_t header_length = encode_header(length, code);
+  std::string format_header(size_t length, opcode code,
+                            bool is_compressed = false) {
+    size_t header_length = encode_header(length, code, is_compressed);
     return {msg_header_, header_length};
   }
 
   std::string encode_frame(std::span<char> &data, opcode op, bool need_mask,
-                           bool eof = true) {
+                           bool eof = true, bool need_compression = false) {
     std::string header;
     /// Base header.
     frame_header hdr{};
     hdr.fin = eof;
     hdr.rsv1 = 0;
-    hdr.rsv2 = 0;
+    if (need_compression)
+      hdr.rsv2 = 1;
+    else
+      hdr.rsv2 = 0;
     hdr.rsv3 = 0;
     hdr.opcode = static_cast<uint8_t>(op);
     hdr.mask = 1;
@@ -227,7 +231,7 @@ class websocket {
   opcode get_opcode() { return (opcode)msg_opcode_; }
 
  private:
-  size_t encode_header(size_t length, opcode code) {
+  size_t encode_header(size_t length, opcode code, bool is_compressed = false) {
     size_t header_length;
 
     if (length < 126) {
@@ -250,6 +254,9 @@ class websocket {
     if (!(flags & SND_CONTINUATION)) {
       msg_header_[0] |= code;
     }
+
+    if (is_compressed)
+      msg_header_[0] |= 0x40;
 
     return header_length;
   }

--- a/tests/test_cinatra_websocket.cpp
+++ b/tests/test_cinatra_websocket.cpp
@@ -278,3 +278,73 @@ TEST_CASE("test client quit after send msg") {
 
   async_simple::coro::syncAwait(test_websocket());
 }
+
+#ifdef CINATRA_ENABLE_GZIP
+TEST_CASE("test websocket permessage defalte") {
+  coro_http_server server(1, 8090);
+  server.set_http_handler<cinatra::GET>(
+      "/ws_extesion",
+      [](coro_http_request &req,
+         coro_http_response &resp) -> async_simple::coro::Lazy<void> {
+        websocket_result result{};
+        while (true) {
+          result = co_await req.get_conn()->read_websocket();
+          if (result.ec) {
+            break;
+          }
+
+          if (result.type == ws_frame_type::WS_CLOSE_FRAME) {
+            std::cout << "close frame\n";
+            break;
+          }
+
+          if (result.type == ws_frame_type::WS_TEXT_FRAME ||
+              result.type == ws_frame_type::WS_BINARY_FRAME) {
+            CHECK(result.data == "test");
+          }
+          else if (result.type == ws_frame_type::WS_PING_FRAME ||
+                   result.type == ws_frame_type::WS_PONG_FRAME) {
+            // ping pong frame just need to continue, no need echo anything,
+            // because framework has reply ping/pong msg to client
+            // automatically.
+            continue;
+          }
+          else {
+            // error frame
+            break;
+          }
+
+          auto ec = co_await req.get_conn()->write_websocket(result.data);
+          if (ec) {
+            break;
+          }
+        }
+      });
+
+  server.async_start();
+
+  coro_http_client client{};
+  REQUIRE(async_simple::coro::syncAwait(
+      client.connect("ws://localhost:8090/ws_extesion", true)));
+
+  std::string send_str("test");
+
+  client.on_ws_msg([&, send_str](resp_data data) {
+    if (data.net_err) {
+      std::cout << "ws_msg net error " << data.net_err.message() << "\n";
+      return;
+    }
+
+    std::cout << "ws msg len: " << data.resp_body.size() << std::endl;
+    REQUIRE(data.resp_body.size() == send_str.size());
+    CHECK(data.resp_body == send_str);
+  });
+
+  async_simple::coro::syncAwait(client.write_websocket(send_str));
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+  server.stop();
+  client.close();
+}
+#endif


### PR DESCRIPTION
websocket permessage-deflate also test by other language.

python websockets test code:


```py
#!/usr/bin/env python

from websockets.sync.client import connect

def hello():
    with connect("ws://192.168.16.2:8090/ws") as websocket:
        s = 'string'.encode('ascii')
        websocket.send(s)
        message = websocket.recv()
        print(f"Received: {message}")

hello()
```

 packets is as follows:

![image](https://github.com/qicosmos/cinatra/assets/20508859/3a2ae186-fbe9-44a1-b985-b64f9fd80aca)

![image](https://github.com/qicosmos/cinatra/assets/20508859/1c47f2c4-6bb0-48fc-94c4-c107f25e0566)


cinatra processing is complete.


