### PR TITLE
set default http handler

### DIFF
--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -550,6 +550,11 @@ class coro_http_server {
 
   void set_shrink_to_fit(bool r) { need_shrink_every_time_ = r; }
 
+  void set_default_handler(
+      std::function<void(coro_http_request &, coro_http_response &)> handler) {
+    default_handler_ = std::move(handler);
+  }
+
   size_t connection_count() {
     std::scoped_lock lock(conn_mtx_);
     return connections_.size();
@@ -654,6 +659,9 @@ class coro_http_server {
       }
       if (need_check_) {
         conn->set_check_timeout(true);
+      }
+      if (default_handler_) {
+        conn->set_default_handler(default_handler_);
       }
 
 #ifdef CINATRA_ENABLE_SSL
@@ -915,6 +923,8 @@ class coro_http_server {
 #endif
   coro_http_router router_;
   bool need_shrink_every_time_ = false;
+  std::function<void(coro_http_request &, coro_http_response &)>
+      default_handler_ = nullptr;
 };
 
 using http_server = coro_http_server;


### PR DESCRIPTION
```cpp
TEST_CASE("test default http handler") {
  coro_http_server server(1, 9001);
  server.set_default_handler([](coro_http_request &req,
                                coro_http_response &resp) {
    resp.set_status_and_content(status_type::ok, "It is from default handler");
  });
  server.async_start();

  for (int i = 0; i < 5; i++) {
    coro_http_client client{};
    async_simple::coro::syncAwait(client.connect("http://127.0.0.1:9001"));
    auto data = client.get("/test");
    CHECK(data.resp_body == "It is from default handler");
    data = client.get("/test_again");
    CHECK(data.resp_body == "It is from default handler");
    data = client.get("/any");
    CHECK(data.resp_body == "It is from default handler");
  }
}
```

