### PR TITLE
fix ssl option

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -294,7 +294,12 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
     bool no_schema = !has_schema(uri);
     std::string append_uri;
     if (no_schema) {
-      append_uri.append("http://").append(uri);
+#ifdef CINATRA_ENABLE_SSL
+      if (is_ssl_schema_)
+        append_uri.append("https://").append(uri);
+      else
+#endif
+        append_uri.append("http://").append(uri);
     }
 
     auto [ok, u] = handle_uri(data, no_schema ? append_uri : uri);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -66,11 +66,14 @@ TEST_CASE("test ssl client") {
     auto result = client4.get("www.baidu.com");
     assert(result.status == 200);
 
-    coro_http_client client5{};
-    client5.set_ssl_schema(true);
-    co_await client5.connect("www.baidu.com");
-    result = co_await client5.async_get("/");
-    assert(result.status == 200);
+    auto lazy = []() -> async_simple::coro::Lazy<void> {
+      coro_http_client client5{};
+      client5.set_ssl_schema(true);
+      co_await client5.connect("www.baidu.com");
+      auto result = co_await client5.async_get("/");
+      assert(result.status == 200);
+    };
+    async_simple::coro::syncAwait(lazy());
   }
   {
     coro_http_client client{};

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -61,6 +61,18 @@ TEST_CASE("test for gzip") {
 #ifdef CINATRA_ENABLE_SSL
 TEST_CASE("test ssl client") {
   {
+    coro_http_client client4{};
+    client4.set_ssl_schema(true);
+    auto result = client4.get("www.baidu.com");
+    assert(result.status == 200);
+
+    coro_http_client client5{};
+    client5.set_ssl_schema(true);
+    co_await client5.connect("www.baidu.com");
+    result = co_await client5.async_get("/");
+    assert(result.status == 200);
+  }
+  {
     coro_http_client client{};
     auto result = client.get("https://www.bing.com");
     CHECK(result.status >= 200);


### PR DESCRIPTION
when client set_ssl_schema(true), client should add `https://` automatically.
```cpp
    coro_http_client client4{};
    client4.set_ssl_schema(true);
    auto result = client4.get("www.baidu.com");
    assert(result.status == 200);

    coro_http_client client5{};
    client5.set_ssl_schema(true);
    co_await client5.connect("www.baidu.com");
    result = co_await client5.async_get("/");
    assert(result.status == 200);
```