### PR TITLE
feat:add br support

### DIFF
--- a/cmake/FindBrotli.cmake
+++ b/cmake/FindBrotli.cmake
@@ -1,0 +1,21 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(BROTLI_INCLUDE_DIR "brotli/decode.h")
+
+find_library(BROTLICOMMON_LIBRARY NAMES brotlicommon)
+find_library(BROTLIDEC_LIBRARY NAMES brotlidec)
+find_library(BROTLIENC_LIBRARY NAMES brotlienc)
+
+find_package_handle_standard_args(Brotli
+    FOUND_VAR
+    BROTLI_FOUND
+    REQUIRED_VARS
+    BROTLIDEC_LIBRARY
+    BROTLICOMMON_LIBRARY
+    BROTLI_INCLUDE_DIR
+    FAIL_MESSAGE
+    "Could NOT find Brotli"
+)
+
+set(BROTLI_INCLUDE_DIRS ${BROTLI_INCLUDE_DIR})
+set(BROTLI_LIBRARIES ${BROTLIDEC_LIBRARY} ${BROTLIENC_LIBRARY} ${BROTLICOMMON_LIBRARY})

--- a/cmake/develop.cmake
+++ b/cmake/develop.cmake
@@ -53,9 +53,12 @@ if(ENABLE_SANITIZER AND NOT MSVC)
     endif()
 endif()
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
+
 SET(ENABLE_GZIP OFF)
 SET(ENABLE_SSL OFF)
 SET(ENABLE_CLIENT_SSL OFF)
+SET(ENABLE_BROTLI OFF)
 
 if (ENABLE_SSL)
 	add_definitions(-DCINATRA_ENABLE_SSL)
@@ -99,5 +102,14 @@ endif()
 if (ENABLE_GZIP)
 	find_package(ZLIB REQUIRED)
 endif()
+
+if (ENABLE_BROTLI)
+	find_package(Brotli REQUIRED)
+	if (Brotli_FOUND)
+		message(STATUS "Brotli found")
+		add_definitions(-DCINATRA_ENABLE_BROTLI)
+	endif (Brotli_FOUND)
+endif(ENABLE_BROTLI)
+
 
 add_definitions(-DCORO_HTTP_PRINT_REQ_HEAD)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 if (ENABLE_BROTLI)
 	include_directories(${BROTLI_INCLUDE_DIRS})
 	target_link_libraries(${project_name} ${BROTLI_LIBRARIES})
-	#target_link_libraries(benchmark PRIVATE ${BROTLI_LIBRARIES})
+	target_link_libraries(benchmark PRIVATE ${BROTLI_LIBRARIES})
 endif()
 
 if (ENABLE_SIMD STREQUAL "AARCH64")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -29,6 +29,12 @@ if (ENABLE_GZIP)
 	target_link_libraries(benchmark PRIVATE ${ZLIB_LIBRARIES})
 endif()
 
+if (ENABLE_BROTLI)
+	include_directories(${BROTLI_INCLUDE_DIRS})
+	target_link_libraries(${project_name} ${BROTLI_LIBRARIES})
+	#target_link_libraries(benchmark PRIVATE ${BROTLI_LIBRARIES})
+endif()
+
 if (ENABLE_SIMD STREQUAL "AARCH64")
 	if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
 		add_library(neon INTERFACE IMPORTED)

--- a/include/cinatra/brzip.hpp
+++ b/include/cinatra/brzip.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include <string>
+#include <string_view>
+#include <array>
+#include <sstream>
+#include <brotli/decode.h>
+#include <brotli/encode.h>
+
+namespace cinatra::br_codec {
+
+#define BROTLI_BUFFER_SIZE 1024
+
+inline bool brotli_compress(std::string_view input, std::string &output)
+{
+        auto instance = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+        std::array<uint8_t, BROTLI_BUFFER_SIZE> buffer;
+        std::stringstream result;
+        
+        size_t available_in = input.size(), available_out = buffer.size();
+        const uint8_t* next_in = reinterpret_cast<const uint8_t*>(input.data());
+        uint8_t* next_out = buffer.data();
+
+        do
+        {
+            int ret = BrotliEncoderCompressStream
+            (
+                instance, BROTLI_OPERATION_FINISH,
+                &available_in, &next_in, &available_out, &next_out, nullptr
+            );
+            if (!ret)
+                return false;
+            result.write(reinterpret_cast<const char*>(buffer.data()), buffer.size() - available_out);
+            available_out = buffer.size();
+            next_out = buffer.data();
+        }
+        while (!(available_in == 0 && BrotliEncoderIsFinished(instance)));
+
+        BrotliEncoderDestroyInstance(instance);
+        output = result.str();
+        return true;
+}
+
+inline bool brotli_decompress(std::string_view input, std::string &decompressed)
+{
+    if (input.size() == 0)
+        return false;
+
+    size_t available_in = input.size();
+    auto next_in = (const uint8_t *)(input.data());
+    decompressed = std::string(available_in * 3, 0);
+    size_t available_out = decompressed.size();
+    auto next_out = (uint8_t *)(decompressed.data());
+    size_t total_out{0};
+    bool done = false;
+    auto s = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+    while (!done) {
+        auto result = BrotliDecoderDecompressStream(
+            s, &available_in, &next_in, &available_out, &next_out, &total_out);
+        if (result == BROTLI_DECODER_RESULT_SUCCESS) {
+            decompressed.resize(total_out);
+            BrotliDecoderDestroyInstance(s);
+            return true;
+        }
+        else if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+            if (total_out != decompressed.size()) {
+                return false;
+            }
+            decompressed.resize(total_out * 2);
+            next_out = (uint8_t *)(decompressed.data() + total_out);
+            available_out = total_out;
+        }
+        else {
+            decompressed.resize(0);
+            BrotliDecoderDestroyInstance(s);
+            return true;
+        }
+    }
+    return true;
+}
+}
+
+// namespace cinatra::br_codec

--- a/include/cinatra/brzip.hpp
+++ b/include/cinatra/brzip.hpp
@@ -1,82 +1,79 @@
 #pragma once
-#include <string>
-#include <string_view>
-#include <array>
-#include <sstream>
 #include <brotli/decode.h>
 #include <brotli/encode.h>
+
+#include <array>
+#include <sstream>
+#include <string>
+#include <string_view>
 
 namespace cinatra::br_codec {
 
 #define BROTLI_BUFFER_SIZE 1024
 
-inline bool brotli_compress(std::string_view input, std::string &output)
-{
-        auto instance = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
-        std::array<uint8_t, BROTLI_BUFFER_SIZE> buffer;
-        std::stringstream result;
-        
-        size_t available_in = input.size(), available_out = buffer.size();
-        const uint8_t* next_in = reinterpret_cast<const uint8_t*>(input.data());
-        uint8_t* next_out = buffer.data();
+inline bool brotli_compress(std::string_view input, std::string &output) {
+  auto instance = BrotliEncoderCreateInstance(nullptr, nullptr, nullptr);
+  std::array<uint8_t, BROTLI_BUFFER_SIZE> buffer;
+  std::stringstream result;
 
-        do
-        {
-            int ret = BrotliEncoderCompressStream
-            (
-                instance, BROTLI_OPERATION_FINISH,
-                &available_in, &next_in, &available_out, &next_out, nullptr
-            );
-            if (!ret)
-                return false;
-            result.write(reinterpret_cast<const char*>(buffer.data()), buffer.size() - available_out);
-            available_out = buffer.size();
-            next_out = buffer.data();
-        }
-        while (!(available_in == 0 && BrotliEncoderIsFinished(instance)));
+  size_t available_in = input.size(), available_out = buffer.size();
+  const uint8_t *next_in = reinterpret_cast<const uint8_t *>(input.data());
+  uint8_t *next_out = buffer.data();
 
-        BrotliEncoderDestroyInstance(instance);
-        output = result.str();
-        return true;
+  do {
+    int ret = BrotliEncoderCompressStream(instance, BROTLI_OPERATION_FINISH,
+                                          &available_in, &next_in,
+                                          &available_out, &next_out, nullptr);
+    if (!ret)
+      return false;
+    result.write(reinterpret_cast<const char *>(buffer.data()),
+                 buffer.size() - available_out);
+    available_out = buffer.size();
+    next_out = buffer.data();
+  } while (!(available_in == 0 && BrotliEncoderIsFinished(instance)));
+
+  BrotliEncoderDestroyInstance(instance);
+  output = result.str();
+  return true;
 }
 
-inline bool brotli_decompress(std::string_view input, std::string &decompressed)
-{
-    if (input.size() == 0)
-        return false;
+inline bool brotli_decompress(std::string_view input,
+                              std::string &decompressed) {
+  if (input.size() == 0)
+    return false;
 
-    size_t available_in = input.size();
-    auto next_in = (const uint8_t *)(input.data());
-    decompressed = std::string(available_in * 3, 0);
-    size_t available_out = decompressed.size();
-    auto next_out = (uint8_t *)(decompressed.data());
-    size_t total_out{0};
-    bool done = false;
-    auto s = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
-    while (!done) {
-        auto result = BrotliDecoderDecompressStream(
-            s, &available_in, &next_in, &available_out, &next_out, &total_out);
-        if (result == BROTLI_DECODER_RESULT_SUCCESS) {
-            decompressed.resize(total_out);
-            BrotliDecoderDestroyInstance(s);
-            return true;
-        }
-        else if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
-            if (total_out != decompressed.size()) {
-                return false;
-            }
-            decompressed.resize(total_out * 2);
-            next_out = (uint8_t *)(decompressed.data() + total_out);
-            available_out = total_out;
-        }
-        else {
-            decompressed.resize(0);
-            BrotliDecoderDestroyInstance(s);
-            return true;
-        }
+  size_t available_in = input.size();
+  auto next_in = (const uint8_t *)(input.data());
+  decompressed = std::string(available_in * 3, 0);
+  size_t available_out = decompressed.size();
+  auto next_out = (uint8_t *)(decompressed.data());
+  size_t total_out{0};
+  bool done = false;
+  auto s = BrotliDecoderCreateInstance(nullptr, nullptr, nullptr);
+  while (!done) {
+    auto result = BrotliDecoderDecompressStream(
+        s, &available_in, &next_in, &available_out, &next_out, &total_out);
+    if (result == BROTLI_DECODER_RESULT_SUCCESS) {
+      decompressed.resize(total_out);
+      BrotliDecoderDestroyInstance(s);
+      return true;
     }
-    return true;
+    else if (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
+      if (total_out != decompressed.size()) {
+        return false;
+      }
+      decompressed.resize(total_out * 2);
+      next_out = (uint8_t *)(decompressed.data() + total_out);
+      available_out = total_out;
+    }
+    else {
+      decompressed.resize(0);
+      BrotliDecoderDestroyInstance(s);
+      return true;
+    }
+  }
+  return true;
 }
-}
+}  // namespace cinatra::br_codec
 
 // namespace cinatra::br_codec

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1590,12 +1590,9 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
 #ifdef CINATRA_ENABLE_BROTLI
       if (encoding_type_ == content_encoding::br) {
-        std::string unbr_str;
-        bool r = br_codec::brotli_decompress(reply, unbr_str);
-        if (r) {
-          data.resp_body = unbr_str;
-          data.br_data = unbr_str;
-        }
+        bool r = br_codec::brotli_decompress(reply, unbr_str_);
+        if (r)
+          data.resp_body = unbr_str_;
         else
           data.resp_body = reply;
 
@@ -2132,6 +2129,10 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
   std::string inflate_str_;
 #endif
   content_encoding encoding_type_ = content_encoding::none;
+
+#ifdef CINATRA_ENABLE_BROTLI
+  std::string unbr_str_;
+#endif
 
 #ifdef BENCHMARK_TEST
   bool stop_bench_ = false;

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -102,7 +102,6 @@ struct resp_data {
   int status = 0;
   bool eof = false;
   std::string_view resp_body;
-  std::string br_data;
   std::span<http_header> resp_headers;
 #ifdef BENCHMARK_TEST
   uint64_t total = 0;

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1447,7 +1447,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         else if (parser_.get_header_value("Content-Encoding").find("deflate") !=
                  std::string_view::npos)
           encoding_type_ = content_encoding::deflate;
-        else if (parser_.get_header_value("Content-Encoding").find("br") != std::string_view::npos)
+        else if (parser_.get_header_value("Content-Encoding").find("br") !=
+                 std::string_view::npos)
           encoding_type_ = content_encoding::br;
       }
       else {
@@ -1567,7 +1568,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
           data.resp_body = unziped_str;
         else
           data.resp_body = reply;
-        
+
         head_buf_.consume(content_len);
         data.eof = (head_buf_.size() == 0);
         co_return;
@@ -1588,17 +1589,16 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 #endif
 
 #ifdef CINATRA_ENABLE_BROTLI
-      if (encoding_type_ == content_encoding::br)
-      {
+      if (encoding_type_ == content_encoding::br) {
         std::string unbr_str;
         bool r = br_codec::brotli_decompress(reply, unbr_str);
         if (r) {
-            data.resp_body = unbr_str;
-            data.br_data = unbr_str;
+          data.resp_body = unbr_str;
+          data.br_data = unbr_str;
         }
         else
           data.resp_body = reply;
-        
+
         head_buf_.consume(content_len);
         data.eof = (head_buf_.size() == 0);
         co_return;

--- a/include/cinatra/coro_http_request.hpp
+++ b/include/cinatra/coro_http_request.hpp
@@ -156,6 +156,8 @@ class coro_http_request {
         return content_encoding::gzip;
       else if (encoding_type.find("deflate") != std::string_view::npos)
         return content_encoding::deflate;
+      else if (encoding_type.find("br") != std::string_view::npos)
+        return content_encoding::br;
       else
         return content_encoding::none;
     }

--- a/include/cinatra/coro_http_response.hpp
+++ b/include/cinatra/coro_http_response.hpp
@@ -122,32 +122,31 @@ class coro_http_response {
 #endif
 
 #ifdef CINATRA_ENABLE_BROTLI
-    if (encoding == content_encoding::br)
-      {
-        if (client_encoding_type.empty() ||
-            client_encoding_type.find("br") != std::string_view::npos) {
-          std::string br_str;
-          bool r = br_codec::brotli_compress(content, br_str);
-          if (!r) {
-            set_status_and_content(status_type::internal_server_error,
-                                  "br compress error");
-          }
-          else {
-            add_header("Content-Encoding", "br");
-            set_content(std::move(br_str));
-          }
+    if (encoding == content_encoding::br) {
+      if (client_encoding_type.empty() ||
+          client_encoding_type.find("br") != std::string_view::npos) {
+        std::string br_str;
+        bool r = br_codec::brotli_compress(content, br_str);
+        if (!r) {
+          set_status_and_content(status_type::internal_server_error,
+                                 "br compress error");
         }
         else {
-          if (is_view) {
-            content_view_ = content;
-          }
-          else {
-            content_ = std::move(content);
-          }
+          add_header("Content-Encoding", "br");
+          set_content(std::move(br_str));
         }
-        has_set_content_ = true;
-        return;
       }
+      else {
+        if (is_view) {
+          content_view_ = content;
+        }
+        else {
+          content_ = std::move(content);
+        }
+      }
+      has_set_content_ = true;
+      return;
+    }
 #endif
 
     if (is_view) {

--- a/include/cinatra/coro_http_response.hpp
+++ b/include/cinatra/coro_http_response.hpp
@@ -15,6 +15,9 @@
 #ifdef CINATRA_ENABLE_GZIP
 #include "gzip.hpp"
 #endif
+#ifdef CINATRA_ENABLE_BROTLI
+#include "brzip.hpp"
+#endif
 #include "picohttpparser.h"
 #include "response_cv.hpp"
 #include "time_util.hpp"
@@ -69,7 +72,7 @@ class coro_http_response {
       if (client_encoding_type.empty() ||
           client_encoding_type.find("gzip") != std::string_view::npos) {
         std::string encode_str;
-        bool r = gzip_codec::compress(content, encode_str, true);
+        bool r = gzip_codec::compress(content, encode_str);
         if (!r) {
           set_status_and_content(status_type::internal_server_error,
                                  "gzip compress error");
@@ -87,8 +90,11 @@ class coro_http_response {
           content_ = std::move(content);
         }
       }
+      has_set_content_ = true;
+      return;
     }
-    else if (encoding == content_encoding::deflate) {
+
+    if (encoding == content_encoding::deflate) {
       if (client_encoding_type.empty() ||
           client_encoding_type.find("deflate") != std::string_view::npos) {
         std::string deflate_str;
@@ -110,16 +116,45 @@ class coro_http_response {
           content_ = std::move(content);
         }
       }
+      has_set_content_ = true;
+      return;
     }
-    else
 #endif
-    {
-      if (is_view) {
-        content_view_ = content;
+
+#ifdef CINATRA_ENABLE_BROTLI
+    if (encoding == content_encoding::br)
+      {
+        if (client_encoding_type.empty() ||
+            client_encoding_type.find("br") != std::string_view::npos) {
+          std::string br_str;
+          bool r = br_codec::brotli_compress(content, br_str);
+          if (!r) {
+            set_status_and_content(status_type::internal_server_error,
+                                  "br compress error");
+          }
+          else {
+            add_header("Content-Encoding", "br");
+            set_content(std::move(br_str));
+          }
+        }
+        else {
+          if (is_view) {
+            content_view_ = content;
+          }
+          else {
+            content_ = std::move(content);
+          }
+        }
+        has_set_content_ = true;
+        return;
       }
-      else {
-        content_ = std::move(content);
-      }
+#endif
+
+    if (is_view) {
+      content_view_ = content;
+    }
+    else {
+      content_ = std::move(content);
     }
     has_set_content_ = true;
   }

--- a/include/cinatra/define.h
+++ b/include/cinatra/define.h
@@ -19,7 +19,7 @@ enum class http_method {
   OPTIONS,
   DEL,
 };
-enum class content_encoding { gzip, deflate, none };
+enum class content_encoding { gzip, deflate, br, none };
 constexpr inline auto GET = http_method::GET;
 constexpr inline auto POST = http_method::POST;
 constexpr inline auto DEL = http_method::DEL;

--- a/press_tool/CMakeLists.txt
+++ b/press_tool/CMakeLists.txt
@@ -26,6 +26,11 @@ if (ENABLE_GZIP)
 	target_link_libraries(${project_name} ${ZLIB_LIBRARIES})
 endif()
 
+if (ENABLE_BROTLI)
+	include_directories(${BROTLI_INCLUDE_DIRS})
+	target_link_libraries(${project_name} ${BROTLI_LIBRARIES})
+endif()
+
 if (ENABLE_SIMD STREQUAL "AARCH64")
     if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "aarch64")
         add_library(neon INTERFACE IMPORTED)
@@ -74,6 +79,11 @@ if (ENABLE_PRESS_TOOL_TESTS)
 
     if (ENABLE_GZIP)
         target_link_libraries(${unittest_press_tool} ${ZLIB_LIBRARIES})
+    endif()
+
+    if (ENABLE_BROTLI)
+        include_directories(${BROTLI_INCLUDE_DIRS})
+        target_link_libraries(${unittest_press_tool} ${BROTLI_LIBRARIES})
     endif()
 
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,11 @@ if (ENABLE_GZIP)
 	target_link_libraries(${project_name} ${ZLIB_LIBRARIES})
 endif()
 
+if (ENABLE_BROTLI)
+	include_directories(${BROTLI_INCLUDE_DIRS})
+	target_link_libraries(${project_name} ${BROTLI_LIBRARIES})
+endif()
+
 # test_coro_file
 option(ENABLE_FILE_IO_URING "enable io_uring" OFF)
 if(ENABLE_FILE_IO_URING)

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -162,7 +162,7 @@ TEST_CASE("test brotli type") {
 
   auto result = async_simple::coro::syncAwait(client.async_post(
       "http://127.0.0.1:9001/get", ziped_str, req_content_type::none, headers));
-  CHECK(result.br_data == "ok");
+  CHECK(result.resp_body == "ok");
   server.stop();
 }
 #endif


### PR DESCRIPTION
add br compression support.

server code:

```c++
int main()
{
  coro_http_server server(1, 9001);

  server.set_http_handler<GET, POST>(
      "/get", [](coro_http_request &req, coro_http_response &resp) {
        auto encoding_type = req.get_encoding_type();

        if (encoding_type == content_encoding::br) {
          std::string decode_str;
          bool r = br_codec::brotli_decompress(req.get_body(), decode_str);
          std::cout << decode_str << std::endl;
        }
        resp.set_status_and_content(status_type::ok, "ok", content_encoding::br,
                                    req.get_accept_encoding());
      });

  server.sync_start();
}
```

python client test code:

```py
import requests
import brotli

additional_headers= {
    'Content-Encoding': 'br'
}
request_body = brotli.compress("Hello world".encode('utf-8'))
r = requests.post('http://192.168.16.2:9001/get', request_body, headers=additional_headers)

print(r.content)
```

Test pass.