### PR TITLE
support async_upload, support async_sendfile() with zerocopy in async_upload & async_chunked_upload

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -75,7 +75,7 @@ async_simple::coro::Lazy<resp_data> chunked_upload1(coro_http_client &client) {
 
   auto fn = [&file, &buf]() -> async_simple::coro::Lazy<read_result> {
     auto [ec, size] = co_await file.async_read(buf.data(), buf.size());
-    co_return read_result{buf, file.eof(), ec};
+    co_return read_result{{buf.data(), buf.size()}, file.eof(), ec};
   };
 
   auto result = co_await client.async_upload_chunked(

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -902,7 +902,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       length -= size;
     }
   }
-
+#ifdef __linux__
   struct fd_guard {
     int fd;
     fd_guard(const char *file_path) : fd(::open(file_path, O_RDONLY)) {}
@@ -973,7 +973,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       }
     } while (true);
   }
-
+#endif
   template <typename stream>
   static std::size_t getRemainingBytes(stream &file) {
     auto current_pos = file.tellg();

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -115,8 +115,8 @@ template <typename String = std::string>
 struct req_context {
   req_content_type content_type = req_content_type::none;
   std::string req_header; /*header string*/
-  String content; /*body*/
-  coro_io::coro_file* resp_body_stream = nullptr; 
+  String content;         /*body*/
+  coro_io::coro_file *resp_body_stream = nullptr;
 };
 
 struct multipart_t {
@@ -1617,7 +1617,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
     if (!ctx.req_header.empty())
       req_str.append(ctx.req_header);
-    size_t content_len=ctx.content.size();
+    size_t content_len = ctx.content.size();
     bool should_add_len = false;
     if (content_len > 0) {
       should_add_len = true;
@@ -1847,7 +1847,8 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
       if (is_ranges) {
         if (ctx.resp_body_stream) {
-          auto ec = co_await ctx.resp_body_stream->async_write(data_ptr, content_len);
+          auto ec =
+              co_await ctx.resp_body_stream->async_write(data_ptr, content_len);
           if (ec) {
             data.net_err = ec;
             co_return;
@@ -1934,7 +1935,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
 
       if (ctx.resp_body_stream) {
         ec = co_await ctx.resp_body_stream->async_write(part_body.data.data(),
-                                              part_body.data.size());
+                                                        part_body.data.size());
       }
       else {
         resp_chunk_str_.append(part_body.data.data(), part_body.data.size());

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -894,12 +894,18 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         close();
         break;
       }
+      length -= size;
+      if (length > 0 && file.eof()) {
+        // bad request, file may smaller than content-length
+        close();
+        ec = std::make_error_code(std::errc::invalid_argument);
+        break;
+      }
       if (std::tie(ec, size) =
               co_await async_write(asio::buffer(file_data.data(), size));
           ec) {
         break;
       }
-      length -= size;
     }
   }
 #ifdef __linux__

--- a/include/cinatra/utils.hpp
+++ b/include/cinatra/utils.hpp
@@ -290,8 +290,9 @@ get_cookies_map(std::string_view cookies_str) {
   return cookies;
 };
 
-template<bool is_first_time,bool is_last_time>
-std::string_view get_chuncked_buffers(size_t length,std::array<char, 24>& buffer) {
+template <bool is_first_time, bool is_last_time>
+std::string_view get_chuncked_buffers(size_t length,
+                                      std::array<char, 24> &buffer) {
   if constexpr (is_last_time) {
     return {"\r\n0\r\n\r\n"};
   }
@@ -312,7 +313,5 @@ std::string_view get_chuncked_buffers(size_t length,std::array<char, 24>& buffer
 }
 
 }  // namespace cinatra
-
-
 
 #endif  // CINATRA_UTILS_HPP

--- a/include/cinatra/utils.hpp
+++ b/include/cinatra/utils.hpp
@@ -290,6 +290,29 @@ get_cookies_map(std::string_view cookies_str) {
   return cookies;
 };
 
+template<bool is_first_time,bool is_last_time>
+std::string_view get_chuncked_buffers(size_t length,std::array<char, 24>& buffer) {
+  if constexpr (is_last_time) {
+    return {"\r\n0\r\n\r\n"};
+  }
+  else {
+    auto [ptr, ec] = std::to_chars(
+        buffer.data() + 2, buffer.data() + buffer.size() - 2, length, 16);
+    *ptr++ = '\r';
+    *ptr++ = '\n';
+    if constexpr (is_first_time) {
+      buffer[0] = '\r';
+      buffer[1] = '\n';
+      return {buffer.data() + 2, ptr};
+    }
+    else {
+      return {buffer.data(), ptr};
+    }
+  }
+}
+
 }  // namespace cinatra
+
+
 
 #endif  // CINATRA_UTILS_HPP

--- a/include/cinatra/ylt/coro_io/coro_file.hpp
+++ b/include/cinatra/ylt/coro_io/coro_file.hpp
@@ -160,18 +160,14 @@ class coro_file {
       fd_file_.reset();
     }
   }
-  
+
   size_t file_size(std::error_code ec) const noexcept {
     return std::filesystem::file_size(file_path_, ec);
   }
 
-  size_t file_size() const {
-    return std::filesystem::file_size(file_path_);
-  }
+  size_t file_size() const { return std::filesystem::file_size(file_path_); }
 
-  std::string_view file_path() const {
-    return file_path_;
-  }
+  std::string_view file_path() const { return file_path_; }
 
   async_simple::coro::Lazy<std::pair<std::error_code, size_t>> async_pread(
       size_t offset, char *data, size_t size) {
@@ -378,7 +374,7 @@ class coro_file {
   async_simple::coro::Lazy<bool> async_open(std::string filepath,
                                             int open_mode = flags::read_write,
                                             read_type type = read_type::fread) {
-    file_path_=std::move(filepath);
+    file_path_ = std::move(filepath);
     type_ = type;
     if (type_ == read_type::pread) {
       co_return open_fd(file_path_, open_mode);
@@ -390,7 +386,8 @@ class coro_file {
 
     auto result = co_await coro_io::post(
         [this, open_mode] {
-          auto fptr = fopen(this->file_path_.data(), str_mode(open_mode).data());
+          auto fptr =
+              fopen(this->file_path_.data(), str_mode(open_mode).data());
           if (fptr == nullptr) {
             std::cout << "line " << __LINE__ << " coro_file open failed "
                       << this->file_path_ << "\n";

--- a/include/cinatra/ylt/coro_io/coro_io.hpp
+++ b/include/cinatra/ylt/coro_io/coro_io.hpp
@@ -25,8 +25,9 @@
 
 #include "../util/type_traits.h"
 #include "io_context_pool.hpp"
-
+#ifdef __linux__
 #include <sys/sendfile.h>
+#endif
 
 namespace coro_io {
 template <typename T>
@@ -516,6 +517,8 @@ inline std::error_code connect(executor_t &executor,
   return error;
 }
 
+#ifdef __linux__
+
 inline async_simple::coro::Lazy<std::pair<std::error_code, std::size_t>>
 async_sendfile(asio::ip::tcp::socket& socket, int fd, off_t offset, size_t size) noexcept {
   std::error_code ec;
@@ -557,4 +560,5 @@ async_sendfile(asio::ip::tcp::socket& socket, int fd, off_t offset, size_t size)
   }
   co_return std::pair{ec,size-least_bytes};
 }
+#endif
 }  // namespace coro_io

--- a/include/cinatra/ylt/coro_io/coro_io.hpp
+++ b/include/cinatra/ylt/coro_io/coro_io.hpp
@@ -26,6 +26,8 @@
 #include "../util/type_traits.h"
 #include "io_context_pool.hpp"
 
+#include <sys/sendfile.h>
+
 namespace coro_io {
 template <typename T>
 constexpr inline bool is_lazy_v =
@@ -514,4 +516,45 @@ inline std::error_code connect(executor_t &executor,
   return error;
 }
 
+inline async_simple::coro::Lazy<std::pair<std::error_code, std::size_t>>
+async_sendfile(asio::ip::tcp::socket& socket, int fd, off_t offset, size_t size) noexcept {
+  std::error_code ec;
+  std::size_t least_bytes = size;
+  if (!ec) [[likely]] { 
+    if (!socket.native_non_blocking()) {
+      socket.native_non_blocking(true, ec);
+      if (ec) {
+        co_return std::pair{ec,0};
+      }
+    }
+    while(true) {
+      // Try the system call.
+      errno = 0;
+      int n = ::sendfile(socket.native_handle(), fd, &offset, std::min(std::size_t{65536},least_bytes));
+      ec = asio::error_code(n < 0 ? errno : 0,
+                            asio::error::get_system_category());
+      least_bytes -= ec ? 0 : n;
+      // total_bytes_transferred += ec ? 0 : n;
+      // Retry operation immediately if interrupted by signal.
+      if (ec == asio::error::interrupted) [[unlikely]]
+        continue;
+      // Check if we need to run the operation again.
+      if (ec == asio::error::would_block || ec == asio::error::try_again) [[unlikely]] { 
+        callback_awaitor<std::error_code> non_block_awaitor;
+        // We have to wait for the socket to become ready again.
+          ec = co_await non_block_awaitor.await_resume([&](auto handler) {
+            socket.async_wait(asio::ip::tcp::socket::wait_write,[handler](const auto& ec){
+              handler.set_value_then_resume(ec);
+            });
+          }); 
+        continue;
+      }
+      if (ec || n == 0 || least_bytes == 0) [[unlikely]] { // End of File
+        break;
+      }
+      // Loop around to try calling sendfile again.
+    }
+  }
+  co_return std::pair{ec,size-least_bytes};
+}
 }  // namespace coro_io

--- a/lang/coroutine_based_http_lib.md
+++ b/lang/coroutine_based_http_lib.md
@@ -451,7 +451,7 @@ coro_http_client client{};
 
   auto fn = [&file, &buf]() -> async_simple::coro::Lazy<read_result> {
     auto [ec, size] = co_await file.async_read(buf.data(), buf.size());
-    co_return read_result{buf, file.eof(), ec};
+    co_return read_result{{buf.data(),buf.size()}, file.eof(), ec};
   };
 
   auto result = co_await client.async_upload_chunked(

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1266,7 +1266,7 @@ TEST_CASE("test coro_http_client chunked upload and download") {
 
           CHECK(!filename.empty());
 
-          std::string oldpath = fs::current_path().append(filename);
+          auto oldpath = fs::current_path().append(filename);
           std::string newpath =
               fs::current_path().append("server_" + std::string{filename});
           std::ofstream file(newpath, std::ios::binary);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1269,8 +1269,9 @@ TEST_CASE("test coro_http_client chunked upload and download") {
           CHECK(!filename.empty());
 
           auto oldpath = fs::current_path().append(filename);
-          std::string newpath =
-              fs::current_path().append("server_" + std::string{filename}).string();
+          std::string newpath = fs::current_path()
+                                    .append("server_" + std::string{filename})
+                                    .string();
           std::ofstream file(newpath, std::ios::binary);
           CHECK(file.is_open());
 

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1176,10 +1176,10 @@ TEST_CASE("test coro_http_client upload") {
       [](coro_http_request &req,
          coro_http_response &resp) -> async_simple::coro::Lazy<void> {
         std::string_view filename = req.get_header_value("filename");
-        std::size_t sz;
+        uint64_t sz;
         auto oldpath = fs::current_path().append(filename);
         std::string newpath =
-            fs::current_path().append("server_" + std::string{filename});
+            fs::current_path().append("server_" + std::string{filename}).string();
         std::ofstream file(newpath, std::ios::binary);
         CHECK(file.is_open());
         file.write(req.get_body().data(), req.get_body().size());

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1270,7 +1270,7 @@ TEST_CASE("test coro_http_client chunked upload and download") {
 
           auto oldpath = fs::current_path().append(filename);
           std::string newpath =
-              fs::current_path().append("server_" + std::string{filename});
+              fs::current_path().append("server_" + std::string{filename}).string();
           std::ofstream file(newpath, std::ios::binary);
           CHECK(file.is_open());
 

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1267,7 +1267,8 @@ TEST_CASE("test coro_http_client chunked upload and download") {
           CHECK(!filename.empty());
 
           std::string oldpath = fs::current_path().append(filename);
-          std::string newpath = fs::current_path().append("server_"+std::string{filename});
+          std::string newpath =
+              fs::current_path().append("server_" + std::string{filename});
           std::ofstream file(newpath, std::ios::binary);
           CHECK(file.is_open());
 
@@ -1299,7 +1300,7 @@ TEST_CASE("test coro_http_client chunked upload and download") {
       if (ec) {
         std::cout << ec << "\n";
       }
-      bool r = create_file(filename,1024*1024*8);
+      bool r = create_file(filename, 1024 * 1024 * 8);
       CHECK(r);
       coro_http_client client{};
       client.add_header("filename", filename);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1178,8 +1178,9 @@ TEST_CASE("test coro_http_client upload") {
         std::string_view filename = req.get_header_value("filename");
         uint64_t sz;
         auto oldpath = fs::current_path().append(filename);
-        std::string newpath =
-            fs::current_path().append("server_" + std::string{filename}).string();
+        std::string newpath = fs::current_path()
+                                  .append("server_" + std::string{filename})
+                                  .string();
         std::ofstream file(newpath, std::ios::binary);
         CHECK(file.is_open());
         file.write(req.get_body().data(), req.get_body().size());
@@ -1187,7 +1188,8 @@ TEST_CASE("test coro_http_client upload") {
         file.close();
         auto filesize = req.get_header_value("filesize");
         if (!filesize.empty()) {
-          std::from_chars(filesize.begin(), filesize.end(), sz);
+          std::from_chars(filesize.data(), filesize.data() + filesize.size(),
+                          sz);
         }
         else {
           sz = std::filesystem::file_size(oldpath);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1177,7 +1177,7 @@ TEST_CASE("test coro_http_client upload") {
          coro_http_response &resp) -> async_simple::coro::Lazy<void> {
         std::string_view filename = req.get_header_value("filename");
         std::size_t sz;
-        std::string oldpath = fs::current_path().append(filename);
+        auto oldpath = fs::current_path().append(filename);
         std::string newpath =
             fs::current_path().append("server_" + std::string{filename});
         std::ofstream file(newpath, std::ios::binary);

--- a/tests/test_cinatra.cpp
+++ b/tests/test_cinatra.cpp
@@ -1186,10 +1186,9 @@ TEST_CASE("test coro_http_client upload") {
         file.write(req.get_body().data(), req.get_body().size());
         file.flush();
         file.close();
-        auto filesize = req.get_header_value("filesize");
+        std::string filesize = std::string{req.get_header_value("filesize")};
         if (!filesize.empty()) {
-          std::from_chars(filesize.data(), filesize.data() + filesize.size(),
-                          sz);
+          sz = stoull(filesize);
         }
         else {
           sz = std::filesystem::file_size(oldpath);

--- a/tests/test_coro_http_server.cpp
+++ b/tests/test_coro_http_server.cpp
@@ -703,7 +703,7 @@ async_simple::coro::Lazy<resp_data> chunked_upload1(coro_http_client &client) {
 
   auto fn = [&file, &buf]() -> async_simple::coro::Lazy<read_result> {
     auto [ec, size] = co_await file.async_read(buf.data(), buf.size());
-    co_return read_result{buf, file.eof(), ec};
+    co_return read_result{{buf.data(), buf.size()}, file.eof(), ec};
   };
 
   auto result = co_await client.async_upload_chunked(


### PR DESCRIPTION
1. add async_upload, user can use this method to upload file in body.
2. support async_sendfile(), which is faster and zero-copy in linux platform
3. async_upload & async_upload_chunked will use async_sendfile() as backend in linux when user pass a string file path as source, which is 2X faster in localhost.