### PR TITLE
perf: Optimize payload length check before reading data

### DIFF
--- a/include/cinatra/coro_http_connection.hpp
+++ b/include/cinatra/coro_http_connection.hpp
@@ -681,14 +681,15 @@ class coro_http_connection
         head_buf_.consume(head_buf_.size());
         std::span<char> payload{};
         auto payload_length = ws_.payload_length();
-        
+
         if (max_part_size_ != 0 && payload_length > max_part_size_) {
           std::string close_reason = "message_too_big";
           std::string close_msg = ws_.format_close_payload(
               close_code::too_big, close_reason.data(), close_reason.size());
           co_await write_websocket(close_msg, opcode::close);
           close();
-          result.ec = std::error_code(asio::error::message_size, asio::error::get_system_category());
+          result.ec = std::error_code(asio::error::message_size,
+                                      asio::error::get_system_category());
           break;
         }
 

--- a/include/cinatra/coro_http_connection.hpp
+++ b/include/cinatra/coro_http_connection.hpp
@@ -688,6 +688,7 @@ class coro_http_connection
               close_code::too_big, close_reason.data(), close_reason.size());
           co_await write_websocket(close_msg, opcode::close);
           close();
+          result.ec = std::error_code(asio::error::message_size, asio::error::get_system_category());
           break;
         }
 


### PR DESCRIPTION
- Moved payload length validation before data reading to prevent unnecessary resource consumption.
- Close the connection immediately if payload length exceeds the allowed limit.