### PR TITLE
fix: add bounds-checking adaption

### DIFF
--- a/include/cinatra/picohttpparser.h
+++ b/include/cinatra/picohttpparser.h
@@ -238,7 +238,7 @@ static const char *get_token_to_eol(const char *buf, const char *buf_end,
                                     int *ret) {
   const char *token_start = buf;
 #ifdef CINATRA_SSE
-  static const char ranges1[] =
+  static const char ALIGNED(16) ranges1[] =
       "\0\010"
       /* allow HT */
       "\012\037"


### PR DESCRIPTION
for [issues 707](https://github.com/qicosmos/cinatra/issues/707)

range1 array is padded to 16 bytes for bounds-checking.