### PR TITLE
默认 range

### DIFF
--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -1000,7 +1000,7 @@ class coro_http_server {
   size_t chunked_size_ = 1024 * 10;
 
   std::unordered_map<std::string, std::string> static_file_cache_;
-  file_resp_format_type format_type_ = file_resp_format_type::chunked;
+  file_resp_format_type format_type_ = file_resp_format_type::range;
 #ifdef CINATRA_ENABLE_SSL
   std::string cert_file_;
   std::string key_file_;


### PR DESCRIPTION
```
curl -I https://example.com/

HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 513
Content-Type: text/html
ETag: "bc2473a18e003bdb249eba5ce893033f:1760028122.592274"
Last-Modified: Thu, 09 Oct 2025 16:42:02 GMT
Cache-Control: max-age=86000
Date: Mon, 17 Nov 2025 14:49:34 GMT
Connection: keep-alive
Alt-Svc: h3=":443"; ma=93600
```