### PR TITLE
fix: avoid UB in `cinatra::coro_http_client::handle_read` when no body bytes are buffered yet

### DIFF
--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1765,6 +1765,10 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
         // copy body.
         if (content_len > 0) {
           auto data_ptr = asio::buffer_cast<const char *>(head_buf_.data());
+          if (data_ptr == nullptr) {
+            ec = std::make_error_code(std::errc::protocol_error);
+            break;
+          }
           if (is_out_buf) {
             memcpy(out_buf_.data(), data_ptr, content_len);
           }
@@ -1782,13 +1786,22 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       size_t part_size = head_buf_.size();
       size_t size_to_read = content_len - part_size;
 
-      auto data_ptr = asio::buffer_cast<const char *>(head_buf_.data());
-      if (is_out_buf) {
-        memcpy(out_buf_.data(), data_ptr, part_size);
+      if (!is_out_buf) {
+          detail::resize(body_, content_len);
       }
-      else {
-        detail::resize(body_, content_len);
-        memcpy(body_.data(), data_ptr, part_size);
+
+      if (part_size > 0) {
+        auto data_ptr = asio::buffer_cast<const char *>(head_buf_.data());
+        if (data_ptr == nullptr) {
+          ec = std::make_error_code(std::errc::protocol_error);
+          break;
+        }
+        if (is_out_buf) {
+          memcpy(out_buf_.data(), data_ptr, part_size);
+        }
+        else {
+          memcpy(body_.data(), data_ptr, part_size);
+        }
       }
 
       head_buf_.consume(part_size);

--- a/include/cinatra/coro_http_client.hpp
+++ b/include/cinatra/coro_http_client.hpp
@@ -1787,7 +1787,7 @@ class coro_http_client : public std::enable_shared_from_this<coro_http_client> {
       size_t size_to_read = content_len - part_size;
 
       if (!is_out_buf) {
-          detail::resize(body_, content_len);
+        detail::resize(body_, content_len);
       }
 
       if (part_size > 0) {


### PR DESCRIPTION
In the partial-content path, `handle_read()` could call `buffer_data_ptr(head_buf_.data())` and pass the returned pointer to `memcpy()` even when `part_size == 0`.

For an empty buffer, `buffer_data_ptr()` returns `nullptr`, which causes UBSanitizer to report:

> runtime error: null pointer passed as argument 2, which is declared to never be null

This patch handles the normal case where response headers have already been received but no body bytes have been buffered yet. Buffered data is now copied only when `part_size > 0`.
