### PR TITLE
Fix deprecated shared_ptr atomic usage in C++20

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,4 +1,4 @@
-name: macOS Monterey 12
+name: macOS
 
 on:
   push:
@@ -23,17 +23,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v6
 
       - name: SetUp HomeBrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c
       
       - name: Install Dependencies
         run: HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install openssl protobuf
 
       - name: Configure CMake
-        run: OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3 CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DCINATRA_ENABLE_SSL=${{matrix.ssl}}
+        run: OPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" CXX=clang++ CC=clang cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.mode}} -DCINATRA_ENABLE_SSL=${{matrix.ssl}}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.mode}}

--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
+
 #include "cinatra/coro_http_client.hpp"
 #include "cinatra/coro_http_response.hpp"
 #include "cinatra/coro_http_router.hpp"
@@ -330,7 +333,7 @@ class coro_http_server {
         }
       }
     }
-    std::atomic_store(&file_cache_, new_cache);
+    file_cache_.store(std::move(new_cache));
   }
 
   const coro_http_router &get_router() const { return router_; }
@@ -434,7 +437,7 @@ class coro_http_server {
     std::string_view mime = get_mime_type(extension);
     auto range_str = req.get_header_value("Range");
 
-    auto cache = std::atomic_load(&file_cache_);
+    auto cache = file_cache_.load();
     if (cache) {
       if (auto it = cache->find(file_name); it != cache->end()) {
         auto range_header = build_range_header(
@@ -840,7 +843,7 @@ class coro_http_server {
       }
 
       if (!result.hasError()) {
-        std::atomic_store(&file_cache_, result.value());
+        file_cache_.store(result.value());
       }
     }
 
@@ -1106,7 +1109,8 @@ class coro_http_server {
   std::string static_dir_ = "";
   size_t chunked_size_ = 1024 * 10;
 
-  std::shared_ptr<std::unordered_map<std::string, std::string>> file_cache_;
+  std::atomic<std::shared_ptr<std::unordered_map<std::string, std::string>>>
+      file_cache_;
   coro_io::period_timer cache_refresh_timer_;
   std::chrono::steady_clock::duration cache_refresh_interval_ =
       std::chrono::seconds(5);

--- a/include/cinatra/coro_http_server.hpp
+++ b/include/cinatra/coro_http_server.hpp
@@ -21,6 +21,9 @@ enum class file_resp_format_type {
   range,
 };
 class coro_http_server {
+  using file_cache_type = std::unordered_map<std::string, std::string>;
+  using file_cache_ptr = std::shared_ptr<file_cache_type>;
+
  public:
   coro_http_server(asio::io_context &ctx, unsigned short port,
                    std::string address = "0.0.0.0")
@@ -333,7 +336,7 @@ class coro_http_server {
         }
       }
     }
-    file_cache_.store(std::move(new_cache));
+    store_file_cache(std::move(new_cache));
   }
 
   const coro_http_router &get_router() const { return router_; }
@@ -437,7 +440,7 @@ class coro_http_server {
     std::string_view mime = get_mime_type(extension);
     auto range_str = req.get_header_value("Range");
 
-    auto cache = file_cache_.load();
+    auto cache = load_file_cache();
     if (cache) {
       if (auto it = cache->find(file_name); it != cache->end()) {
         auto range_header = build_range_header(
@@ -843,7 +846,7 @@ class coro_http_server {
       }
 
       if (!result.hasError()) {
-        file_cache_.store(result.value());
+        store_file_cache(result.value());
       }
     }
 
@@ -1083,6 +1086,24 @@ class coro_http_server {
   }
 
  private:
+  void store_file_cache(file_cache_ptr cache) {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+    file_cache_.store(std::move(cache));
+#else
+    std::atomic_store(&file_cache_, std::move(cache));
+#endif
+  }
+
+  file_cache_ptr load_file_cache() const {
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+    return file_cache_.load();
+#else
+    return std::atomic_load(&file_cache_);
+#endif
+  }
+
   std::unique_ptr<coro_io::io_context_pool> pool_;
   asio::io_context *out_ctx_ = nullptr;
   std::unique_ptr<coro_io::ExecutorWrapper<>> out_executor_ = nullptr;
@@ -1109,8 +1130,12 @@ class coro_http_server {
   std::string static_dir_ = "";
   size_t chunked_size_ = 1024 * 10;
 
-  std::atomic<std::shared_ptr<std::unordered_map<std::string, std::string>>>
-      file_cache_;
+#if defined(__cpp_lib_atomic_shared_ptr) && \
+    __cpp_lib_atomic_shared_ptr >= 201711L
+  std::atomic<file_cache_ptr> file_cache_;
+#else
+  file_cache_ptr file_cache_;
+#endif
   coro_io::period_timer cache_refresh_timer_;
   std::chrono::steady_clock::duration cache_refresh_interval_ =
       std::chrono::seconds(5);


### PR DESCRIPTION
## Summary

- replace deprecated `std::atomic_load`/`std::atomic_store` overloads for `std::shared_ptr`
- use the C++20 `std::atomic<std::shared_ptr<T>>` specialization
- include the required standard headers directly

## Why

MSVC reports STL4029 as C4996 when deprecation warnings are treated as errors in C++20 builds.

## Validation

- built the `test_cinatra` target with Visual Studio 2022 in C++20 mode
- ran `test static res dir dynamic file detection`: 1 test case and 8 assertions passed
- ran `git diff --check`